### PR TITLE
Collapsable multi select list

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Also the following css variables are exposed to clients and can be use to overri
 </d2l-labs-multi-select-list>
 ```
 
+You can opt for a condensed view by adding the `collapsed` attribute, which limits the element to the first line of items and provides a button for viewing the remaining items.
+
 ### Events
 
 - `d2l-labs-multi-select-list-item-deleted`: fired on item deletion

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Also the following css variables are exposed to clients and can be use to overri
 </d2l-labs-multi-select-list>
 ```
 
-You can opt for a condensed view by adding the `collapsed` attribute, which limits the element to the first line of items and provides a button for viewing the remaining items.
+You can opt for a condensed view by adding the `collapsable` attribute, which limits the element to the first line of items and provides a button for viewing the remaining items.
 
 ### Events
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -68,7 +68,7 @@
 			<h3>d2l-labs-multi-select-list collapsed</h3>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-labs-multi-select-list collapse autoremove>
+					<d2l-labs-multi-select-list collapsed autoremove>
 						<d2l-labs-multi-select-list-item deletable="" text="List item 0"></d2l-labs-multi-select-list-item>
 						<d2l-labs-multi-select-list-item deletable="" text="List item 1"></d2l-labs-multi-select-list-item>
 						<d2l-labs-multi-select-list-item deletable="" text="List item 2"></d2l-labs-multi-select-list-item>

--- a/demo/index.html
+++ b/demo/index.html
@@ -87,7 +87,6 @@
 				</template>
 			</d2l-demo-snippet>
 			<script>
-
 				var runAfterLoadeded = function() {
 					const slottedDemo = document.getElementById('slotted-input-demo');
 					const button = document.getElementById('slotted-input-demo-button');

--- a/demo/index.html
+++ b/demo/index.html
@@ -65,6 +65,19 @@
 					</d2l-labs-multi-select-list>
 				</template>
 			</d2l-demo-snippet>
+			<h3>d2l-labs-multi-select-list collapsed</h3>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-labs-multi-select-list collapse autoremove>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 0"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 1"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 2"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 3"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 4"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 5"></d2l-labs-multi-select-list-item>
+					</d2l-labs-multi-select-list>
+				</template>
+			</d2l-demo-snippet>
 			<h3>Show delete icon on hover/focus only</h3>
 			<d2l-demo-snippet>
 				<template>
@@ -74,7 +87,7 @@
 				</template>
 			</d2l-demo-snippet>
 			<script>
-				
+
 				var runAfterLoadeded = function() {
 					const slottedDemo = document.getElementById('slotted-input-demo');
 					const button = document.getElementById('slotted-input-demo-button');
@@ -99,7 +112,7 @@
 						}
 					});
 				};
-				
+
 				runAfterLoadeded();
 			</script>
 		</d2l-demo-page>

--- a/demo/index.html
+++ b/demo/index.html
@@ -68,13 +68,13 @@
 			<h3>d2l-labs-multi-select-list collapsed</h3>
 			<d2l-demo-snippet>
 				<template>
-					<d2l-labs-multi-select-list collapsed autoremove>
-						<d2l-labs-multi-select-list-item deletable="" text="List item 0"></d2l-labs-multi-select-list-item>
-						<d2l-labs-multi-select-list-item deletable="" text="List item 1"></d2l-labs-multi-select-list-item>
-						<d2l-labs-multi-select-list-item deletable="" text="List item 2"></d2l-labs-multi-select-list-item>
-						<d2l-labs-multi-select-list-item deletable="" text="List item 3"></d2l-labs-multi-select-list-item>
-						<d2l-labs-multi-select-list-item deletable="" text="List item 4"></d2l-labs-multi-select-list-item>
-						<d2l-labs-multi-select-list-item deletable="" text="List item 5"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list collapsable autoremove>
+						<d2l-labs-multi-select-list-item deletable="" text="0"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="1"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="2"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="3"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="4"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="5"></d2l-labs-multi-select-list-item>
 					</d2l-labs-multi-select-list>
 				</template>
 			</d2l-demo-snippet>

--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -13,39 +13,51 @@ D2L.PolymerBehaviors.D2LMultiSelect.LocalizeBehaviorImpl = {
 				return {
 					'ar': {
 						'delete': 'حذف',
+						'hiddenChildren': '+ {num} more',
 					},
 					'en': {
 						'delete': 'Delete',
+						'hiddenChildren': '+ {num} more',
 					},
 					'es': {
 						'delete': 'Eliminar',
+						'hiddenChildren': '+ {num} more',
 					},
 					'fr': {
 						'delete': 'Supprimer',
+						'hiddenChildren': '+ {num} more',
 					},
 					'ja': {
 						'delete': '削除',
+						'hiddenChildren': '+ {num} more',
 					},
 					'ko': {
 						'delete': '삭제',
+						'hiddenChildren': '+ {num} more',
 					},
 					'nl': {
 						'delete': 'Verwijderen',
+						'hiddenChildren': '+ {num} more',
 					},
 					'pt': {
 						'delete': 'Excluir',
+						'hiddenChildren': '+ {num} more',
 					},
 					'sv': {
 						'delete': 'Ta bort',
+						'hiddenChildren': '+ {num} more',
 					},
 					'tr': {
 						'delete': 'Sil',
+						'hiddenChildren': '+ {num} more',
 					},
 					'zh': {
 						'delete': '删除',
+						'hiddenChildren': '+ {num} more',
 					},
 					'zh-tw': {
 						'delete': '刪除',
+						'hiddenChildren': '+ {num} more',
 					}
 				};
 			}

--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -13,8 +13,8 @@ D2L.PolymerBehaviors.D2LMultiSelect.LocalizeBehaviorImpl = {
 				return {
 					'ar': {
 						'delete': 'حذف',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': 'إخفاء',
+						'hiddenChildren': '+ {num} أكثر',
 					},
 					'en': {
 						'delete': 'Delete',
@@ -23,53 +23,53 @@ D2L.PolymerBehaviors.D2LMultiSelect.LocalizeBehaviorImpl = {
 					},
 					'es': {
 						'delete': 'Eliminar',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': 'Ocultar',
+						'hiddenChildren': '+ {num} más',
 					},
 					'fr': {
 						'delete': 'Supprimer',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': 'Masquer',
+						'hiddenChildren': '+ {num} plus',
 					},
 					'ja': {
 						'delete': '削除',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': '表示しない',
+						'hiddenChildren': '+ {num} 増やす',
 					},
 					'ko': {
 						'delete': '삭제',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': '숨기기',
+						'hiddenChildren': '+ {num} 더 많이',
 					},
 					'nl': {
 						'delete': 'Verwijderen',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': 'Verbergen',
+						'hiddenChildren': '+ {num} meer',
 					},
 					'pt': {
 						'delete': 'Excluir',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': 'Ocultar',
+						'hiddenChildren': '+ {num} mais',
 					},
 					'sv': {
 						'delete': 'Ta bort',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': 'Dölj',
+						'hiddenChildren': '+ {num} mer',
 					},
 					'tr': {
 						'delete': 'Sil',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': 'Gizle',
+						'hiddenChildren': '+ {num} daha',
 					},
 					'zh': {
 						'delete': '删除',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': '隐藏',
+						'hiddenChildren': '+ {num} 更多',
 					},
 					'zh-tw': {
 						'delete': '刪除',
-						'hide': 'Hide',
-						'hiddenChildren': '+ {num} more',
+						'hide': '隱藏',
+						'hiddenChildren': '+ {num} 其他',
 					}
 				};
 			}

--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -13,50 +13,62 @@ D2L.PolymerBehaviors.D2LMultiSelect.LocalizeBehaviorImpl = {
 				return {
 					'ar': {
 						'delete': 'حذف',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'en': {
 						'delete': 'Delete',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'es': {
 						'delete': 'Eliminar',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'fr': {
 						'delete': 'Supprimer',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'ja': {
 						'delete': '削除',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'ko': {
 						'delete': '삭제',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'nl': {
 						'delete': 'Verwijderen',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'pt': {
 						'delete': 'Excluir',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'sv': {
 						'delete': 'Ta bort',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'tr': {
 						'delete': 'Sil',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'zh': {
 						'delete': '删除',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					},
 					'zh-tw': {
 						'delete': '刪除',
+						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
 					}
 				};

--- a/multi-select-list-item.js
+++ b/multi-select-list-item.js
@@ -25,7 +25,9 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-labs-multi-select-l
 				};
 				width: max-content;
 			}
-
+			:host([_fallback-css]) {
+				min-width: 125px;
+			}
 			.d2l-labs-multi-select-list-item-wrapper {
 				@apply --d2l-labs-multi-select-list-item-font;
 				-moz-user-select: none;

--- a/multi-select-list-item.js
+++ b/multi-select-list-item.js
@@ -23,6 +23,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-labs-multi-select-l
 				--d2l-labs-multi-select-list-item-font: {
 					@apply --d2l-body-compact-text;
 				};
+				width: max-content;
 			}
 
 			.d2l-labs-multi-select-list-item-wrapper {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -38,6 +38,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			}
 			.aux-button {
 				display: inline-block;
+				padding: 0.15rem;
 			}
 			.hide-aux {
 				display: none;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -211,15 +211,15 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
-		let newHiddenChildren = 0;
 		const widthOfListItems = this.shadowRoot.querySelector('div[role="row"]').clientWidth;
-		for (const listItem of children) {
+		for (let i = 0; i < children.length; i++) {
+			const listItem = children[i];
 			childrenWidthTotal += listItem.clientWidth;
 			if (childrenWidthTotal > widthOfListItems) {
-				newHiddenChildren++;
+				this.hiddenChildren = children.length - i;
+				break;
 			}
 		}
-		this.hiddenChildren = newHiddenChildren;
 	}
 	addItem(item) {
 		if (this._currentlyFocusedElement === null) {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -211,11 +211,11 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
-		const widthOfListItems = this.shadowRoot.querySelector('div[role="row"]').clientWidth;
+		const widthOfListItems = this.shadowRoot.querySelector('div[role="row"]').getBoundingClientRect().width;
 		let newHiddenChildren = 0;
 		for (let i = 0; i < children.length; i++) {
 			const listItem = children[i];
-			childrenWidthTotal += listItem.clientWidth;
+			childrenWidthTotal += listItem.getBoundingClientRect().width;
 			if (childrenWidthTotal > widthOfListItems) {
 				newHiddenChildren = children.length - i;
 				break;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -25,7 +25,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			}
 
 			div[collapse] {
-				max-height: 35px;
+				max-height: 1.94rem;
 				overflow: hidden;
 			}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -209,12 +209,13 @@ class D2LMultiSelectList extends mixinBehaviors(
 		if (!this.collapsed) {
 			return;
 		}
-		this.childrenWidthTotal = 0;
+		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
 		let newHiddenChildren = 0;
+		const widthOfListItems = this.shadowRoot.querySelector('div[role="row"]').clientWidth;
 		for (const listItem of children) {
-			this.childrenWidthTotal += listItem.clientWidth;
-			if (this.childrenWidthTotal > this.shadowRoot.querySelector('div[role="row"]').clientWidth) {
+			childrenWidthTotal += listItem.clientWidth;
+			if (childrenWidthTotal > widthOfListItems) {
 				newHiddenChildren++;
 			}
 		}

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -21,7 +21,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				width: 100%;
 				flex-direction: column;
 			}
-			:host([collapsed]) {
+			:host([_collapsed]) {
 				flex-direction: row;
 			}
 			div[role="row"] {
@@ -46,15 +46,15 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: none;
 			}
 		</style>
-			<div role="row" collapse$=[[collapsed]]>
+			<div role="row" collapse$=[[_collapsed]]>
 				<slot></slot>
-				<div class$="[[_hideVisibility(collapsable, collapsed)]]">
+				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 					<d2l-button-subtle text="[[localize('hide')]]" on-click="_expandCollapse" ></d2l-button-subtle>
 					<slot name="aux-button"></slot>
 				</div>
 
 			</div>
-			<div class$="[[_showMoreVisibility(collapsable, collapsed, hiddenChildren)]]">
+			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
 				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" on-click="_expandCollapse"></d2l-labs-multi-select-list-item>
 			</div>
 	</template>
@@ -109,7 +109,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 			/**
 			 * internal reflected attribute that shows the current state
 			 */
-			collapsed: {
+			_collapsed: {
 				type: Boolean,
 				value: false,
 				reflectToAttribute: true
@@ -221,22 +221,22 @@ class D2LMultiSelectList extends mixinBehaviors(
 	_getVisibileEffectiveChildren() {
 		const children = this.getEffectiveChildren();
 		const auxButton = this.collapsable ? getComposedChildren(this.shadowRoot.querySelector('.aux-button')) : [];
-		const hiddenChildren = this.collapsed ? this.hiddenChildren : 0;
+		const hiddenChildren = this._collapsed ? this.hiddenChildren : 0;
 		const vChildren = children.slice(0, children.length - hiddenChildren).concat(auxButton);
 		return vChildren;
 	}
-	_showMoreVisibility(collapsable, collapsed, hiddenChildren) {
-		return collapsable && collapsed && hiddenChildren > 0 ? 'aux-button' : 'hide';
+	_showMoreVisibility(collapsable, _collapsed, hiddenChildren) {
+		return collapsable && _collapsed && hiddenChildren > 0 ? 'aux-button' : 'hide';
 	}
-	_hideVisibility(collapsable, collapsed) {
-		return collapsable && !collapsed ? '' : 'hide';
+	_hideVisibility(collapsable, _collapsed) {
+		return collapsable && !_collapsed ? '' : 'hide';
 	}
 	_debounceChildren() {
 		this._debounceJob = Debouncer.debounce(this._debounceJob,
 			microTask, () => this._updateChildren());
 	}
 	_expandCollapse() {
-		this.collapsed = !this.collapsed;
+		this._collapsed = !this._collapsed;
 	}
 	_updateChildren() {
 		if (!this.collapsable) {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -31,19 +31,17 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			}
 			.aux-button {
 				display: inline-block;
-				width: 25%;
 			}
 
 		</style>
-
-		<div role="row" collapse$=[[collapsed]]>
-			<slot></slot>
-		</div>
-		<template is="dom-if" if="[[_hasHiddenChildren(collapsed, hiddenChildren)]]">
-			<div class="aux-button" >
-				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" on-click="collapseExpand"></d2l-labs-multi-select-list-item>
+			<div role="row" collapse$=[[collapsed]]>
+				<slot></slot>
 			</div>
-		</template>
+			<template is="dom-if" if="[[_hasHiddenChildren(collapsed, hiddenChildren)]]">
+				<div class="aux-button" >
+					<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" on-click="collapseExpand"></d2l-labs-multi-select-list-item>
+				</div>
+			</template>
 	</template>
 </dom-module>`;
 
@@ -132,7 +130,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		let newHiddenChildren = 0;
 		for (const listItem of children) {
 			this.childrenWidthTotal += listItem.clientWidth;
-			if (this.childrenWidthTotal > this.clientWidth) {
+			if (this.childrenWidthTotal > this.shadowRoot.querySelector('div[role="row"]').clientWidth) {
 				newHiddenChildren++;
 			}
 		}
@@ -144,7 +142,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	connectedCallback() {
 		super.connectedCallback();
 		// Set up for d2l-focusable-arrowkeys-behavior
-		this.arrowKeyFocusablesContainer = this;
+		this.arrowKeyFocusablesContainer = this.shadowRoot;
 		this.arrowKeyFocusablesDirection = 'updownleftright';
 		this.arrowKeyFocusablesNoWrap = true;
 		this.arrowKeyFocusablesProvider = this.focusableProvider;
@@ -175,9 +173,8 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 	_onListItemFocus(event) {
-		console.log(event);
 		this._currentlyFocusedElement.tabIndex = -1;
-		this._currentlyFocusedElement = event.originalTarget;
+		this._currentlyFocusedElement = event.target;
 		this._currentlyFocusedElement.tabIndex = 0;
 	}
 
@@ -195,12 +192,10 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 	_onKeyDown(event) {
-		console.log(event);
 		const { BACKSPACE, DELETE } = this._keyCodes;
 		const { keyCode } = event;
 		const rootTarget = event.composedPath()[0];
 		const itemIndex = this._getVisibileEffectiveChildren().indexOf(rootTarget);
-		console.log(itemIndex);
 		if ((keyCode === BACKSPACE || keyCode === DELETE) && itemIndex !== -1) {
 			event.preventDefault();
 			event.stopPropagation();

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -1,11 +1,15 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import 'd2l-polymer-behaviors/d2l-focusable-arrowkeys-behavior.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { microTask } from '@polymer/polymer/lib/utils/async.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+
+import 'd2l-polymer-behaviors/d2l-focusable-arrowkeys-behavior.js';
+import 'd2l-resize-aware/resize-observer-polyfill.js';
+
 import './localize-behavior.js';
+
 const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 	<template strip-whitespace>

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -212,14 +212,16 @@ class D2LMultiSelectList extends mixinBehaviors(
 		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
 		const widthOfListItems = this.shadowRoot.querySelector('div[role="row"]').clientWidth;
+		let newHiddenChildren = 0;
 		for (let i = 0; i < children.length; i++) {
 			const listItem = children[i];
 			childrenWidthTotal += listItem.clientWidth;
 			if (childrenWidthTotal > widthOfListItems) {
-				this.hiddenChildren = children.length - i;
+				newHiddenChildren = children.length - i;
 				break;
 			}
 		}
+		this.hiddenChildren = newHiddenChildren;
 	}
 	addItem(item) {
 		if (this._currentlyFocusedElement === null) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@brightspace-ui/core": "^1",
     "@polymer/polymer": "^3",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
+    "d2l-resize-aware": "BrightspaceUI/resize-aware#semver:^1",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7"


### PR DESCRIPTION
In Portfolio we have a need to use this component, but when a user has many tags we'd like the option to collapse them with the option to expand to view all of them.

This is the tentative design:
![image](https://user-images.githubusercontent.com/1779270/77012122-59df1300-693b-11ea-9760-5d02a01c6a28.png)

Demo of this pr
![ezgif com-resize](https://user-images.githubusercontent.com/1779270/77021298-4db37f80-6954-11ea-9fa4-55e2ae3c63a6.gif)
