### PR TITLE
Fix collapsing bug

### DIFF
--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -27,6 +27,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			div[role="row"] {
 				display: flex;
 				flex-wrap: wrap;
+				flex: 1;
 			}
 
 			div[collapse] {


### PR DESCRIPTION
fix bug where sometimes adding a new element would cause it to collapse the list even if there was enough room

this was caused by the row really only being as big as it's contents

Flex 1 fixes this because the row element will expand to fit it's container regardless of the content