### PR TITLE
multi-select-list focus behaviour changes

### DIFF
--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -293,22 +293,24 @@ class D2LMultiSelectList extends mixinBehaviors(
 	 * _handleFocusChangeOnResize()
 	 *
 	 * Handle element focusing when the parent is resized
-	 * 
+	 *
 	 * if focused element gets hidden
 	 * 		focus the 'show more' button
 	 * else if 'show more' button is focused and it dissapears (no more collapsed elements)
 	 * 		focus the last element in the list
-	 * 
+	 *
 	 * @param {number} focusedIndex - Index of the currently focused element
 	 * @param {number} hiddenIndex - First index of list children where hiding begins
 	 * @param {number} newHiddenChildren - The number of new hidden children after the resize
-	 * 
+	 *
 	 */
 	_handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren) {
 		if (isComposedAncestor(this, getComposedActiveElement())) {
 			if (newHiddenChildren > this.hiddenChildren) {
 				if (this._collapsed && focusedIndex >= hiddenIndex) {
-					this.__focusLast(this._getVisibileEffectiveChildren());
+					afterNextRender(this, () => {
+						this.__focusLast(this._getVisibileEffectiveChildren());
+					});
 				}
 			} else if (newHiddenChildren < this.hiddenChildren && focusedIndex === -1 && newHiddenChildren === 0) {
 				afterNextRender(this, () => {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -292,10 +292,17 @@ class D2LMultiSelectList extends mixinBehaviors(
 	/**
 	 * _handleFocusChangeOnResize()
 	 *
+	 * Handle element focusing when the parent is resized
+	 * 
 	 * if focused element gets hidden
 	 * 		focus the 'show more' button
 	 * else if 'show more' button is focused and it dissapears (no more collapsed elements)
 	 * 		focus the last element in the list
+	 * 
+	 * @param {number} focusedIndex - Index of the currently focused element
+	 * @param {number} hiddenIndex - First index of list children where hiding begins
+	 * @param {number} newHiddenChildren - The number of new hidden children after the resize
+	 * 
 	 */
 	_handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren) {
 		if (isComposedAncestor(this, getComposedActiveElement())) {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -268,9 +268,11 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 	_expandCollapse() {
 		this._collapsed = !this._collapsed;
-		afterNextRender(this, () => {
-			this.__focusLast(this._getVisibileEffectiveChildren());
-		});
+		if (isComposedAncestor(this, getComposedActiveElement())) {
+			afterNextRender(this, () => {
+				this.__focusLast(this._getVisibileEffectiveChildren());
+			});
+		}
 	}
 	_updateChildren() {
 		if (!this.collapsable) {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -283,14 +283,14 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 		const focusedIndex = children.indexOf(this._currentlyFocusedElement);
 		const hiddenIndex = children.length - newHiddenChildren;
-		this._handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren)
-		
+		this._handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren);
+
 		this.hiddenChildren = newHiddenChildren;
 	}
 
 	/**
 	 * _handleFocusChangeOnResize()
-	 * 
+	 *
 	 * if focused element gets hidden
 	 * 		focus the 'show more' button
 	 * else if 'show more' button is focused and it dissapears (no more collapsed elements)

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -302,7 +302,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	_handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren) {
 		const focusedElementHidden = newHiddenChildren > this.hiddenChildren && this._collapsed && focusedIndex >= hiddenIndex;
 		const focusedShowMoreButtonHidden = newHiddenChildren < this.hiddenChildren && focusedIndex === -1 && newHiddenChildren === 0;
-		
+
 		if (focusedElementHidden || focusedShowMoreButtonHidden) {
 			this._focusLastVisibleElement();
 		}
@@ -310,7 +310,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	/**
 	 * _focusLastVisibleElement()
 	 *
-	 * If the component has focus on the page, focus the last visible element 
+	 * If the component has focus on the page, focus the last visible element
 	 *
 	 */
 	_focusLastVisibleElement() {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -12,7 +12,6 @@ import 'd2l-polymer-behaviors/d2l-focusable-arrowkeys-behavior.js';
 import 'd2l-resize-aware/resize-observer-polyfill.js';
 
 import './localize-behavior.js';
-import { root } from '@polymer/polymer/lib/utils/path';
 
 const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -259,7 +259,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 	_expandCollapse() {
 		this._collapsed = !this._collapsed;
-		console.log(this._collapsed)
+
 		if (isComposedAncestor(this, getComposedActiveElement())) {
 			afterNextRender(this, () => {
 				this.__focusLast(this._getVisibileEffectiveChildren());

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -244,7 +244,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this._collapsed = !this._collapsed;
 		afterNextRender(this, () => {
 			this.__focusLast(this._getVisibileEffectiveChildren());
-		})
+		});
 	}
 	_updateChildren() {
 		if (!this.collapsable) {
@@ -263,7 +263,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 			}
 		}
 		if (this.hiddenChildren < newHiddenChildren) {
-			const focusedIndex = children.indexOf(this._currentlyFocusedElement) 
+			const focusedIndex = children.indexOf(this._currentlyFocusedElement);
 			const hiddenIndex = children.length - newHiddenChildren;
 			if (this._collapsed && focusedIndex >= hiddenIndex) {
 				this.__focusLast(this._getVisibileEffectiveChildren());

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -282,12 +282,24 @@ class D2LMultiSelectList extends mixinBehaviors(
 				break;
 			}
 		}
+		const focusedIndex = children.indexOf(this._currentlyFocusedElement);
+		const hiddenIndex = children.length - newHiddenChildren;
+		this._handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren)
+		
+		this.hiddenChildren = newHiddenChildren;
+	}
 
+	/**
+	 * _handleFocusChangeOnResize()
+	 * 
+	 * if focused element gets hidden
+	 * 		focus the 'show more' button
+	 * else if 'show more' button is focused and it dissapears (no more collapsed elements)
+	 * 		focus the last element in the list
+	 */
+	_handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren) {
 		if (isComposedAncestor(this, getComposedActiveElement())) {
-			// if the active element gets collapsed, focus the last element
-			const focusedIndex = children.indexOf(this._currentlyFocusedElement);
 			if (newHiddenChildren > this.hiddenChildren) {
-				const hiddenIndex = children.length - newHiddenChildren;
 				if (this._collapsed && focusedIndex >= hiddenIndex) {
 					this.__focusLast(this._getVisibileEffectiveChildren());
 				}
@@ -297,7 +309,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 				});
 			}
 		}
-		this.hiddenChildren = newHiddenChildren;
 	}
 	addItem(item) {
 		if (this._currentlyFocusedElement === null) {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -224,10 +224,10 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 	_getVisibileEffectiveChildren() {
 		const children = this.getEffectiveChildren();
-		const auxButton = this.collapsable ? getComposedChildren(this.shadowRoot.querySelector('.aux-button')) : [];
-		const hideButton = (this.collapsable && !this._collapsed) ? [this.shadowRoot.querySelector('.hide-button')] : [];
+		const auxButton = (this.collapsable && getComposedChildren(this.shadowRoot.querySelector('.aux-button'))) || [];
+		const hideButton = (this.collapsable && !this._collapsed && [this.shadowRoot.querySelector('.hide-button')]) || [];
 		const hiddenChildren = this._collapsed ? this.hiddenChildren : 0;
-		const vChildren = children.slice(0, children.length - hiddenChildren).concat(auxButton || []).concat(hideButton || []);
+		const vChildren = children.slice(0, children.length - hiddenChildren).concat(auxButton).concat(hideButton);
 		return vChildren;
 	}
 	_showMoreVisibility(collapsable, _collapsed, hiddenChildren) {
@@ -272,7 +272,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		} else if (newHiddenChildren === 0) {
 			afterNextRender(this, () => {
 				this.__focusLast(this._getVisibileEffectiveChildren());
-			})
+			});
 		}
 		this.hiddenChildren = newHiddenChildren;
 	}

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -259,12 +259,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 	_expandCollapse() {
 		this._collapsed = !this._collapsed;
-
-		if (isComposedAncestor(this, getComposedActiveElement())) {
-			afterNextRender(this, () => {
-				this.__focusLast(this._getVisibileEffectiveChildren());
-			});
-		}
+		this._focusLastVisibleElement();
 	}
 	_updateChildren() {
 		if (!this.collapsable) {
@@ -305,18 +300,24 @@ class D2LMultiSelectList extends mixinBehaviors(
 	 *
 	 */
 	_handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren) {
+		const focusedElementHidden = newHiddenChildren > this.hiddenChildren && this._collapsed && focusedIndex >= hiddenIndex;
+		const focusedShowMoreButtonHidden = newHiddenChildren < this.hiddenChildren && focusedIndex === -1 && newHiddenChildren === 0;
+		
+		if (focusedElementHidden || focusedShowMoreButtonHidden) {
+			this._focusLastVisibleElement();
+		}
+	}
+	/**
+	 * _focusLastVisibleElement()
+	 *
+	 * If the component has focus on the page, focus the last visible element 
+	 *
+	 */
+	_focusLastVisibleElement() {
 		if (isComposedAncestor(this, getComposedActiveElement())) {
-			if (newHiddenChildren > this.hiddenChildren) {
-				if (this._collapsed && focusedIndex >= hiddenIndex) {
-					afterNextRender(this, () => {
-						this.__focusLast(this._getVisibileEffectiveChildren());
-					});
-				}
-			} else if (newHiddenChildren < this.hiddenChildren && focusedIndex === -1 && newHiddenChildren === 0) {
-				afterNextRender(this, () => {
-					this.__focusLast(this._getVisibileEffectiveChildren());
-				});
-			}
+			afterNextRender(this, () => {
+				this.__focusLast(this._getVisibileEffectiveChildren());
+			});
 		}
 	}
 	addItem(item) {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -51,13 +51,13 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			<div role="row" collapse$=[[_collapsed]]>
 				<slot></slot>
 				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
-					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="false"></d2l-button-subtle>
+					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 					<slot name="aux-button"></slot>
 				</div>
 
 			</div>
 			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
-				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="true"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
 			</div>
 	</template>
 </dom-module>`;
@@ -259,6 +259,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 	_expandCollapse() {
 		this._collapsed = !this._collapsed;
+		console.log(this._collapsed)
 		if (isComposedAncestor(this, getComposedActiveElement())) {
 			afterNextRender(this, () => {
 				this.__focusLast(this._getVisibileEffectiveChildren());

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -58,7 +58,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 
 			</div>
 			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
-				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onKeyUp" aria-expanded="true"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="true"></d2l-labs-multi-select-list-item>
 			</div>
 	</template>
 </dom-module>`;
@@ -199,7 +199,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 	_onKeyDown(event) {
-		const { BACKSPACE, DELETE, ENTER } = this._keyCodes;
+		const { BACKSPACE, DELETE } = this._keyCodes;
 		const { keyCode } = event;
 		const rootTarget = event.composedPath()[0];
 		const itemIndex = this._getVisibileEffectiveChildren().indexOf(rootTarget);
@@ -218,15 +218,19 @@ class D2LMultiSelectList extends mixinBehaviors(
 			}
 			rootTarget._onDeleteItem();
 		}
+	}
+	_onShowButtonKeyDown(event) {
+		const { ENTER } = this._keyCodes;
+		const { keyCode } = event;
 
-		if (keyCode === ENTER && rootTarget.classList.contains('show-button')) {
+		if (keyCode === ENTER) {
 			event.preventDefault();
 			event.stopPropagation();
 			this._expandCollapse();
 		}
 	}
 
-	_onKeyUp(event) {
+	_onShowButtonKeyUp(event) {
 		const { SPACE } = this._keyCodes;
 		const { keyCode } = event;
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -296,7 +296,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	 *
 	 * if focused element gets hidden
 	 * 		focus the 'show more' button
-	 * else if 'show more' button is focused and it dissapears (no more collapsed elements)
+	 * else if 'show more' button is focused and it disappears (no more collapsed elements)
 	 * 		focus the last element in the list
 	 *
 	 * @param {number} focusedIndex - Index of the currently focused element

--- a/test/multi-select-list.html
+++ b/test/multi-select-list.html
@@ -121,27 +121,28 @@
 						});
 					});
 				});
+
 				describe('collapsable', function() {
 					let showButton, hideButton;
 					beforeEach(function(done) {
 						listFixture = fixture('collapsable');
-						showButton = listFixture.shadowRoot.querySelector('.show-button')
-						hideButton = listFixture.shadowRoot.querySelector('.hide-button')
+						showButton = listFixture.shadowRoot.querySelector('.show-button');
+						hideButton = listFixture.shadowRoot.querySelector('.hide-button');
 						afterNextRender(listFixture, done);
 					});
 
 					it('should render only items that fit', function() {
 						// note: this is related to the max-width being set by the fixture
-						expect(listFixture.hiddenChildren).to.equal(6)
+						expect(listFixture.hiddenChildren).to.equal(6);
 					});
 
-					it('should expand/collapse the list when show/hide buttons are clicked', function () {						
+					it('should expand/collapse the list when show/hide buttons are clicked', function() {
 						expect(listFixture._collapsed).to.be.true;
-						
-						MockInteractions.tap(showButton)		
+
+						MockInteractions.tap(showButton);
 						expect(listFixture._collapsed).to.be.false;
-						
-						MockInteractions.tap(hideButton)
+
+						MockInteractions.tap(hideButton);
 						expect(listFixture._collapsed).to.be.true;
 					});
 
@@ -149,19 +150,19 @@
 						it('should expand/collapse list when enter is pressed on show/hide toggle', function() {
 							expect(listFixture._collapsed).to.be.true;
 
-							MockInteractions.keyDownOn(showButton, _keyCodes.ENTER);												
+							MockInteractions.keyDownOn(showButton, _keyCodes.ENTER);
 							expect(listFixture._collapsed).to.be.false;
 
-							MockInteractions.tap(hideButton)
+							MockInteractions.tap(hideButton);
 							expect(listFixture._collapsed).to.be.true;
 						});
 
 						it('should expand/collapse list when space is pressed on show/hide toggle', function() {
 							expect(listFixture._collapsed).to.be.true;
-							
+
 							MockInteractions.keyUpOn(showButton, _keyCodes.SPACE);
 							expect(listFixture._collapsed).to.be.false;
-							
+
 							MockInteractions.tap(hideButton);
 							expect(listFixture._collapsed).to.be.true;
 						});

--- a/test/multi-select-list.html
+++ b/test/multi-select-list.html
@@ -65,7 +65,7 @@
 						});
 
 						function testDeleteAndFocus(itemToDelete, expectedFocusItem, keyCode, done) {
-							MockInteractions.keyUpOn(itemToDelete, keyCode);
+							MockInteractions.keyDownOn(itemToDelete, keyCode);
 
 							afterNextRender(listFixture, function() {
 								expect(document.getElementById(itemToDelete.id)).to.be.null;

--- a/test/multi-select-list.html
+++ b/test/multi-select-list.html
@@ -65,7 +65,7 @@
 						});
 
 						function testDeleteAndFocus(itemToDelete, expectedFocusItem, keyCode, done) {
-							MockInteractions.keyDownOn(itemToDelete, keyCode);
+							MockInteractions.keyUpOn(itemToDelete, keyCode);
 
 							afterNextRender(listFixture, function() {
 								expect(document.getElementById(itemToDelete.id)).to.be.null;

--- a/test/multi-select-list.html
+++ b/test/multi-select-list.html
@@ -18,6 +18,23 @@
 				</d2l-labs-multi-select-list>
 			</template>
 		</test-fixture>
+		<test-fixture id="collapsable">
+			<template>
+				<d2l-labs-multi-select-list collapsable autoremove style="max-width: 500px;">
+					<d2l-labs-multi-select-list-item id="item0" deletable text="item0"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item1" deletable text="item1"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item2" deletable text="item2"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item3" deletable text="item3"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item4" deletable text="item4"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item5" deletable text="item5"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item6" deletable text="item6"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item7" deletable text="item7"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item8" deletable text="item8"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item9" deletable text="item9"></d2l-labs-multi-select-list-item>
+					<d2l-labs-multi-select-list-item id="item10" deletable text="item10"></d2l-labs-multi-select-list-item>
+				</d2l-labs-multi-select-list>
+			</template>
+		</test-fixture>
 		<script type="module">
 			import '@polymer/iron-test-helpers/mock-interactions.js';
 			import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
@@ -27,7 +44,7 @@
 			import '../multi-select-list-item.js';
 			describe('<d2l-labs-multi-select-list>', function() {
 				let listFixture;
-				const _keyCodes = { BACKSPACE: 8, DELETE: 46 };
+				const _keyCodes = { BACKSPACE: 8, DELETE: 46, ENTER: 13, SPACE: 32 };
 
 				describe('basic', function() {
 					beforeEach(function(done) {
@@ -101,6 +118,52 @@
 							expect(document.getElementById(item0.id).tabIndex).to.equal(-1);
 							expect(document.getElementById(item1.id).tabIndex).to.equal(0);
 							expect(document.getElementById(item2.id).tabIndex).to.equal(-1);
+						});
+					});
+				});
+				describe('collapsable', function() {
+					let showButton, hideButton;
+					beforeEach(function(done) {
+						listFixture = fixture('collapsable');
+						showButton = listFixture.shadowRoot.querySelector('.show-button')
+						hideButton = listFixture.shadowRoot.querySelector('.hide-button')
+						afterNextRender(listFixture, done);
+					});
+
+					it('should render only items that fit', function() {
+						// note: this is related to the max-width being set by the fixture
+						expect(listFixture.hiddenChildren).to.equal(6)
+					});
+
+					it('should expand/collapse the list when show/hide buttons are clicked', function () {						
+						expect(listFixture._collapsed).to.be.true;
+						
+						MockInteractions.tap(showButton)		
+						expect(listFixture._collapsed).to.be.false;
+						
+						MockInteractions.tap(hideButton)
+						expect(listFixture._collapsed).to.be.true;
+					});
+
+					describe('keyboard-behavior', function() {
+						it('should expand/collapse list when enter is pressed on show/hide toggle', function() {
+							expect(listFixture._collapsed).to.be.true;
+
+							MockInteractions.keyDownOn(showButton, _keyCodes.ENTER);												
+							expect(listFixture._collapsed).to.be.false;
+
+							MockInteractions.tap(hideButton)
+							expect(listFixture._collapsed).to.be.true;
+						});
+
+						it('should expand/collapse list when space is pressed on show/hide toggle', function() {
+							expect(listFixture._collapsed).to.be.true;
+							
+							MockInteractions.keyUpOn(showButton, _keyCodes.SPACE);
+							expect(listFixture._collapsed).to.be.false;
+							
+							MockInteractions.tap(hideButton);
+							expect(listFixture._collapsed).to.be.true;
 						});
 					});
 				});


### PR DESCRIPTION
### Original bug
When focusing the "show more" button, then navigating focus elsewhere on the page, previously you would be unable to regain focus of the `multi-select`.

### Changes
- Modify the `_onListItemFocus` to get the focused element differently
- Fix an issue where the "hide" button wasn't accessible with arrow keys
- When collapsing/expanding, give focus to the hide/show button after the action has completed
- If an element is focused and gets hidden, put focus on the "show more" button

### ⚠️ Outstanding issues
- [x] `subtle-buttons` treat spacebar as a `keyUp`, and 'enter' key as `keyDown` ~....not sure what to do about that~ **thank you @apalaniuk for your help**
- [x] On initial load an `expandCollapse` is triggered, which subsequently focuses the last element in the list (the expand/collapse button). 
  - Maybe add further checking inside `expandCollapse` 
