### PR TITLE
Prevent default spacebar behaviour when focused

### DIFF
--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -219,13 +219,15 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 	}
 	_onShowButtonKeyDown(event) {
-		const { ENTER } = this._keyCodes;
+		const { ENTER, SPACE } = this._keyCodes;
 		const { keyCode } = event;
 
 		if (keyCode === ENTER) {
 			event.preventDefault();
 			event.stopPropagation();
 			this._expandCollapse();
+		} else if (keyCode === SPACE) {
+			event.preventDefault();
 		}
 	}
 


### PR DESCRIPTION
@apalaniuk noticed when the list is focused and the spacebar is pressed, the page scrolls (default behaviour).

Since we want the space bar to act as a button press, prevent the default event from occurring.