### PR TITLE
US117889 Prevent tooltip cutoff by removing position rule on multi-select-list-item

### DIFF
--- a/multi-select-list-item.js
+++ b/multi-select-list-item.js
@@ -15,7 +15,6 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-labs-multi-select-l
 				cursor: pointer;
 				display: inline-block;
 				outline: none;
-				position: relative;
 				--d2l-labs-multi-select-list-item-padding: 0.25rem 0.75rem 0.2rem;
 				--d2l-labs-multi-select-list-item-padding-rtl: 0.25rem 0.75rem 0.2rem;
 				--d2l-labs-multi-select-list-item-padding-deletable: 0.25rem 0.4rem 0.2rem 0.75rem;


### PR DESCRIPTION
When a multi-select list is positioned close to the edge of the containing element, the relative positioning was causing the tooltip to be cut off:
![image](https://user-images.githubusercontent.com/32819802/86175621-8842c180-bad8-11ea-80c6-89c82157919d.png)
This is due to the d2l-tooltip component having the `position: absolute`. In most cases the parent elements are default static elements so the containing block ends up being the body or html root (or some other higher-level element). However, if a wrapper around the d2l-tooltip is positioned (e.g. has `position: relative`), then that wrapper becomes the containing block. If any ancestors of that wrapper have set `overflow: hidden` then that is respected.

In my case, this was happening in the FACE editor where the primary-secondary template hides overflow, which along with the relatively positioned multi-select-list-item parent of the tooltip results in the tooltip being cut off.

Reviewed the code and did some regression testing on several uses in the LMS, and removing the rule doesn't appear to break anything. I think it might be a vestige of the original implementation.

https://rally1.rallydev.com/#/29180338367d/detail/userstory/399753248600