### PR TITLE
Added class to div containing multi-select-list items

### DIFF
--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -25,7 +25,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			:host([_collapsed]) {
 				flex-direction: row;
 			}
-			div[role="list"] {
+			.list-item-container {
 				display: flex;
 				flex-wrap: wrap;
 				flex: 1;
@@ -36,7 +36,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				overflow: hidden;
 			}
 
-			div[role="list"] > ::slotted(d2l-labs-multi-select-list-item) {
+			.list-item-container > ::slotted(d2l-labs-multi-select-list-item) {
 				padding: 0.15rem;
 				display: block;
 			}
@@ -48,7 +48,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: none;
 			}
 		</style>
-			<div role="list" collapse$=[[_collapsed]]>
+			<div class="list-item-container" collapse$=[[_collapsed]]>
 				<slot></slot>
 				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
@@ -147,6 +147,8 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this.observer = new ResizeObserver(this._debounceChildren);
 		this.observer.observe(this);
 		this._nodeObserver = new FlattenedNodesObserver(this, this._debounceChildren);
+
+		this.setAttribute('role', 'list');
 
 		afterNextRender(this, function() {
 			const listItems = this.getEffectiveChildren();
@@ -268,7 +270,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
-		const widthOfListItems = this.shadowRoot.querySelector('div[role="list"]').getBoundingClientRect().width;
+		const widthOfListItems = this.shadowRoot.querySelector('.list-item-container').getBoundingClientRect().width;
 		let newHiddenChildren = 0;
 		for (let i = 0; i < children.length; i++) {
 			const listItem = children[i];


### PR DESCRIPTION
https://rally1.rallydev.com/#/detail/userstory/395253921988?fdp=true

This is related to the above issue.

This resolves a regression introduced by [this PR (1)](https://github.com/BrightspaceUILabs/multi-select/pull/57/files) that caused facet-filter-sort in [this PR (2)](https://github.com/BrightspaceUI/facet-filter-sort/pull/54) to no longer have NVDA announce "Applied Filters" when you enter the Applied Filters component. In PR (1), the role of list moved from being on the `d2l-labs-multi-select-list` component to being on a div, causing `aria-labelledby` to not work properly. My change uses a CSS class to get around that problem.