### PR TITLE
bypassing d2l-input-text validation

### DIFF
--- a/multi-select-input-text.js
+++ b/multi-select-input-text.js
@@ -25,6 +25,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-input-tex
 				aria-label$="[[ariaLabel]]"
 				aria-labelledby$="[[ariaLabelledby]]"
 				autofocus$="[[autofocus]]"
+				novalidate
 				on-input="_onInput"
 				on-keypress="_onKeyPress"
 				placeholder$="[[placeholder]]"


### PR DESCRIPTION
@AllanKerr FYI as you're not a member of the org

`d2l-input-text` is about to have validation enabled, which will suddenly start checking for min/max/required. Since we're not sure how this will impact places that weren't expecting it, we're disabling it for now.