### PR TITLE
Intrepid US120036 - Add support for "shrinkwrapping" the row

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ button.addEventListener('click', () => {
 ```
 
 #### `shrinkwrap` property on `d2l-labs-multi-select-list`
-boolean - If this is excluded, all shrinkwrapping functionality is disabled.
+(boolean) - If this is excluded, all shrinkwrapping functionality is disabled.
 
 #### `shrinkwrap-maximum-size` property on `d2l-labs-multi-select-list`
-string - Shrinkwrapping works by creating the maximum size flexbox, and then determining how many filter buttons can fit within the space, and then shrinking the flexbox to match that. This parameter specifies the size to start shrinking from (if excluded, algorithm will try its best). This parameter is a CSS width string (ex: 450px or 75%)
+(string) - Shrinkwrapping works by creating the maximum size flexbox, and then determining how many filter buttons can fit within the space, and then shrinking the flexbox to match that. This parameter specifies the size to start shrinking from (if excluded, algorithm will try its best). This parameter is a CSS width string (ex: 450px or 75%)
 
 #### `show-clear-list` property on `d2l-labs-multi-select-list`
 (boolean) - If this is true, then the "clear list" button appears. Clicking this dispatches the event `d2l-multi-select-list-clear-list-clicked` which must be handled by the parent to perform proper list clearing.

--- a/README.md
+++ b/README.md
@@ -70,14 +70,11 @@ button.addEventListener('click', () => {
 #### `shrinkwrap` property on `d2l-labs-multi-select-list`
 (boolean) - If this is excluded, all shrinkwrapping functionality is disabled.
 
-#### `shrinkwrap-maximum-size` property on `d2l-labs-multi-select-list`
-(string) - Shrinkwrapping works by creating the maximum size flexbox, and then determining how many filter buttons can fit within the space, and then shrinking the flexbox to match that. This parameter specifies the size to start shrinking from (if excluded, algorithm will try its best). This parameter is a CSS width string (ex: 450px or 75%)
-
 #### `show-clear-list` property on `d2l-labs-multi-select-list`
 (boolean) - If this is true, then the "clear list" button appears. Clicking this dispatches the event `d2l-multi-select-list-clear-list-clicked` which must be handled by the parent to perform proper list clearing.
 
 #### `clear-list-button-text` property on `d2l-labs-multi-select-list`
-(boolean) - Sets the text to display in the clear list button.  Defaults to the `clearList` langterm.
+(string) - Sets the text to display in the clear list button.  Defaults to the `clearList` langterm.
 
 ### Components
 

--- a/README.md
+++ b/README.md
@@ -67,15 +67,6 @@ button.addEventListener('click', () => {
 })
 ```
 
-#### `shrinkwrap` property on `d2l-labs-multi-select-list`
-(boolean) - If this is excluded, all shrinkwrapping functionality is disabled.
-
-#### `show-clear-list` property on `d2l-labs-multi-select-list`
-(boolean) - If this is true, then the "clear list" button appears. Clicking this dispatches the event `d2l-multi-select-list-clear-list-clicked` which must be handled by the parent to perform proper list clearing.
-
-#### `clear-list-button-text` property on `d2l-labs-multi-select-list`
-(string) - Sets the text to display in the clear list button.  Defaults to the `clearList` langterm.
-
 ### Components
 
 #### `d2l-labs-multi-select-list-item`
@@ -111,6 +102,15 @@ Also the following css variables are exposed to clients and can be use to overri
 ```
 
 You can opt for a condensed view by adding the `collapsable` attribute, which limits the element to the first line of items and provides a button for viewing the remaining items.
+
+#### `shrinkwrap` property on `d2l-labs-multi-select-list`
+(boolean) - If this is excluded, all shrinkwrapping functionality is disabled.
+
+#### `show-clear-list` property on `d2l-labs-multi-select-list`
+(boolean) - If this is true, then the "clear list" button appears. Clicking this dispatches the event `d2l-multi-select-list-clear-list-clicked` which must be handled by the parent to perform proper list clearing.
+
+#### `clear-list-button-text` property on `d2l-labs-multi-select-list`
+(string) - Sets the text to display in the clear list button.  Defaults to the `clearList` langterm.
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ button.addEventListener('click', () => {
 })
 ```
 
+#### `shrinkwrap` property on `d2l-labs-multi-select-list`
+boolean - If this is excluded, all shrinkwrapping functionality is disabled.
+
+#### `shrinkwrap-maximum-size` property on `d2l-labs-multi-select-list`
+string - Shrinkwrapping works by creating the maximum size flexbox, and then determining how many filter buttons can fit within the space, and then shrinking the flexbox to match that. This parameter specifies the size to start shrinking from (if excluded, algorithm will try its best). This parameter is a CSS width string (ex: 450px or 75%)
+
+#### `show-clear-list` property on `d2l-labs-multi-select-list`
+(boolean) - If this is true, then the "clear list" button appears. Clicking this dispatches the event `d2l-multi-select-list-clear-list-clicked` which must be handled by the parent to perform proper list clearing.
+
+#### `clear-list-button-text` property on `d2l-labs-multi-select-list`
+(boolean) - Sets the text to display in the clear list button.  Defaults to the `clearList` langterm.
+
 ### Components
 
 #### `d2l-labs-multi-select-list-item`
@@ -108,6 +120,8 @@ You can opt for a condensed view by adding the `collapsable` attribute, which li
 - `d2l-labs-multi-select-list-item-deleted`: fired on item deletion
 
 - `d2l-labs-multi-select-list-item-added`: fired on item added to the `d2l-labs-multi-select-list`
+
+- `d2l-multi-select-list-clear-list-clicked`: fired when the clear list button is clicked
 
 ## Developing, Testing and Contributing
 

--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -20,7 +20,7 @@ D2L.PolymerBehaviors.D2LMultiSelect.LocalizeBehaviorImpl = {
 						'delete': 'Delete',
 						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
-						'clearFilters': 'Clear Filters'
+						'clearList': 'Clear List'
 					},
 					'es': {
 						'delete': 'Eliminar',

--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -20,6 +20,7 @@ D2L.PolymerBehaviors.D2LMultiSelect.LocalizeBehaviorImpl = {
 						'delete': 'Delete',
 						'hide': 'Hide',
 						'hiddenChildren': '+ {num} more',
+						'clearFilters': 'Clear Filters'
 					},
 					'es': {
 						'delete': 'Eliminar',

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -46,7 +46,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			.hide {
 				display: none;
 			}
-			.subtle-button-baseline {
+			d2l-button-subtle {
 				height: 30px;
 				margin-top: -2px;
 			}
@@ -54,18 +54,18 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			<div class="list-item-container" collapse$=[[_collapsed]]>
 				<slot></slot>
 				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
-					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button subtle-button-baseline" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
+					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 				</div>
 				<div class$="[[_hideClearListVisibility(collapsable, _collapsed, showClearList)]]">
-					<d2l-button-subtle text="[[_getClearListText()]]" on-click="clearListClicked" class="subtle-button-baseline"></d2l-button-subtle>
+					<d2l-button-subtle text="[[_getClearListText()]]" on-click="clearListClicked"></d2l-button-subtle>
 				</div>
 			</div>
 			<slot name="aux-button"></slot>
 			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
-				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false" class="subtle-button-baseline"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
 			</div>
 			<div class$="[[_clearListVisibility(collapsable, _collapsed, showClearList)]]">
-				<d2l-button-subtle text="[[_getClearListText()]]" on-click="clearListClicked" class="subtle-button-baseline"></d2l-button-subtle>
+				<d2l-button-subtle text="[[_getClearListText()]]" on-click="clearListClicked"></d2l-button-subtle>
 			</div>
 	</template>
 </dom-module>`;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -43,10 +43,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: inline-block;
 				padding: 0.15rem;
 			}
-			.clear-filters {
-				display: inline-block;
-				padding: 0.15rem;
-			}
 			.hide {
 				display: none;
 			}
@@ -60,16 +56,16 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button subtle-button-baseline" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 				</div>
-				<div class$="[[_hideClearFiltersVisibility(collapsable, _collapsed, showClearFilters)]]">
-					<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked" class="subtle-button-baseline"></d2l-button-subtle>
+				<div class$="[[_hideClearListVisibility(collapsable, _collapsed, showClearList)]]">
+					<d2l-button-subtle text="[[_getClearListText()]]" on-click="clearListClicked" class="subtle-button-baseline"></d2l-button-subtle>
 				</div>
 			</div>
 			<slot name="aux-button"></slot>
 			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
 				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false" class="subtle-button-baseline"></d2l-labs-multi-select-list-item>
 			</div>
-			<div class$="[[_clearFiltersVisibility(collapsable, _collapsed, showClearFilters)]]">
-				<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked" class="subtle-button-baseline"></d2l-button-subtle>
+			<div class$="[[_clearListVisibility(collapsable, _collapsed, showClearList)]]">
+				<d2l-button-subtle text="[[_getClearListText()]]" on-click="clearListClicked" class="subtle-button-baseline"></d2l-button-subtle>
 			</div>
 	</template>
 </dom-module>`;
@@ -151,11 +147,18 @@ class D2LMultiSelectList extends mixinBehaviors(
 				value: ''
 			},
 			/**
-			 * Whether or not to display a clear filters button
+			 * Whether or not to display a clear list button
 			 */
-			showClearFilters: {
+			showClearList: {
 				type: Boolean,
 				value: false
+			},
+			/**
+			 * Text to show for clear list button
+			 */
+			clearListButtonText: {
+				type: String,
+				value: ''
 			}
 		};
 	}
@@ -166,8 +169,12 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this._debounceChildren = this._debounceChildren.bind(this);
 	}
 
-	clearFiltersClicked() {
-		this.dispatchEvent(new CustomEvent('d2l-multi-select-list-clear-filters-clicked', {}));
+	_getClearListText() {
+		return this.clearListButtonText || localize('clearList');
+	}
+
+	clearListClicked() {
+		this.dispatchEvent(new CustomEvent('d2l-multi-select-list-clear-list-clicked', {}));
 	}
 
 	connectedCallback() {
@@ -290,14 +297,14 @@ class D2LMultiSelectList extends mixinBehaviors(
 	_showMoreVisibility(collapsable, _collapsed, hiddenChildren) {
 		return collapsable && _collapsed && hiddenChildren > 0 ? 'aux-button' : 'hide';
 	}
-	_clearFiltersVisibility(collapsable, _collapsed, showClearFilters) {
-		return showClearFilters && collapsable && _collapsed ? 'clear-filters' : 'hide';
+	_clearListVisibility(collapsable, _collapsed, showClearList) {
+		return showClearList && collapsable && _collapsed ? '' : 'hide';
 	}
 	_hideVisibility(collapsable, _collapsed) {
 		return collapsable && !_collapsed ? '' : 'hide';
 	}
-	_hideClearFiltersVisibility(collapsable, _collapsed, showClearFilters) {
-		return showClearFilters && collapsable && !_collapsed ? '' : 'hide';
+	_hideClearListVisibility(collapsable, _collapsed, showClearList) {
+		return showClearList && collapsable && !_collapsed ? '' : 'hide';
 	}
 	_debounceChildren() {
 		this._debounceJob = Debouncer.debounce(this._debounceJob,

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -140,13 +140,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 				value: false
 			},
 			/**
-			 * The maximum width to allow when shrinkwrapping
-			 */
-			shrinkwrapMaximumSize: {
-				type: String,
-				value: ''
-			},
-			/**
 			 * Whether or not to display a clear list button
 			 */
 			showClearList: {
@@ -320,7 +313,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 
 		if (this.shrinkwrap) {
-			this._resetWidth(this.shrinkwrapMaximumSize);
+			this.shadowRoot.querySelector('.list-item-container').style['max-width'] = 'unset';
 		}
 
 		let childrenWidthTotal = 0;
@@ -336,9 +329,9 @@ class D2LMultiSelectList extends mixinBehaviors(
 				if (this.shrinkwrap) {
 					let desiredWidth = 0;
 					for (let j = 0; j < i; j++) {
-						desiredWidth += children[j].getBoundingClientRect().width; //margins
+						desiredWidth += children[j].getBoundingClientRect().width;
 					}
-					this._updateWidth(desiredWidth);
+					this.shadowRoot.querySelector('.list-item-container').style['max-width'] = `${desiredWidth}px`;
 					widthSet = true;
 				}
 
@@ -348,7 +341,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 
 		if (!widthSet && this.shrinkwrap) {
-			this._updateWidth(childrenWidthTotal);
+			this.shadowRoot.querySelector('.list-item-container').style['max-width'] = `${childrenWidthTotal}px`;
 		}
 
 		const focusedIndex = children.indexOf(this._currentlyFocusedElement);
@@ -356,16 +349,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this._handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren);
 
 		this.hiddenChildren = newHiddenChildren;
-	}
-
-	_updateWidth(width) {
-		if (width > 0) {
-			this.shadowRoot.querySelector('.list-item-container').style.width = (width + 1) + 'px';
-		}
-	}
-
-	_resetWidth(width) {
-		this.shadowRoot.querySelector('.list-item-container').style.width = width || 'auto';
 	}
 
 	/**

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -312,13 +312,15 @@ class D2LMultiSelectList extends mixinBehaviors(
 			return;
 		}
 
+		const container = this.shadowRoot.querySelector('.list-item-container');
+
 		if (this.shrinkwrap) {
-			this.shadowRoot.querySelector('.list-item-container').style['max-width'] = 'unset';
+			container.style['max-width'] = 'unset';
 		}
 
 		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
-		const widthOfListItems = this.shadowRoot.querySelector('.list-item-container').getBoundingClientRect().width;
+		const widthOfListItems = container.getBoundingClientRect().width;
 		let newHiddenChildren = 0;
 
 		for (let i = 0; i < children.length; i++) {
@@ -332,7 +334,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 
 		if (this.shrinkwrap) {
-			this.shadowRoot.querySelector('.list-item-container').style['max-width'] = `${childrenWidthTotal}px`;
+			container.style['max-width'] = `${childrenWidthTotal}px`;
 		}
 
 		const focusedIndex = children.indexOf(this._currentlyFocusedElement);

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -360,18 +360,12 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 	_updateWidth(width) {
 		if (width > 0) {
-			const d = this.shadowRoot.querySelector('.list-item-container');
-			if (d) {
-				d.style.width = (width + 1) + 'px';
-			}
+			this.shadowRoot.querySelector('.list-item-container').style.width = (width + 1) + 'px';
 		}
 	}
 
 	_resetWidth(width) {
-		const d = this.shadowRoot.querySelector('.list-item-container');
-		if (d) {
-			d.style.width = width || '';
-		}
+		this.shadowRoot.querySelector('.list-item-container').style.width = width || 'auto';
 	}
 
 	/**

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -43,6 +43,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: inline-block;
 				padding: 0.15rem;
 			}
+			.clear-filters {
+				display: inline-block'
+			}
 			.hide {
 				display: none;
 			}
@@ -52,12 +55,17 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 				</div>
+				<div class$="[[_hideClearFiltersVisibility(collapsable, _collapsed, showClearFilters)]]">
+					<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked"></d2l-button-subtle>
+				</div>
 			</div>
 			<slot name="aux-button"></slot>
 			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
 				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
 			</div>
-			<d2l-button-subtle id="d2l-clear-filters-button" text="Clear Filters"></d2l-button-subtle>
+			<div class$="[[_clearFiltersVisibility(collapsable, _collapsed, showClearFilters)]]">
+				<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked"></d2l-button-subtle>
+			</div>
 	</template>
 </dom-module>`;
 
@@ -135,6 +143,13 @@ class D2LMultiSelectList extends mixinBehaviors(
 			 */
 			shrinkwrapMaximumSize: {
 				type: String,
+				value: ""
+			},
+			/**
+			 * Whether or not to display a clear filters button
+			 */
+			showClearFilters: {
+				type: Boolean,
 				value: false
 			}
 		};
@@ -144,6 +159,10 @@ class D2LMultiSelectList extends mixinBehaviors(
 		super();
 		this._onListItemDeleted = this._onListItemDeleted.bind(this);
 		this._debounceChildren = this._debounceChildren.bind(this);
+	}
+
+	clearFiltersClicked() {
+		this.dispatchEvent(new CustomEvent('d2l-multi-select-list-clear-filters-clicked', {}));
 	}
 
 	connectedCallback() {
@@ -266,8 +285,14 @@ class D2LMultiSelectList extends mixinBehaviors(
 	_showMoreVisibility(collapsable, _collapsed, hiddenChildren) {
 		return collapsable && _collapsed && hiddenChildren > 0 ? 'aux-button' : 'hide';
 	}
+	_clearFiltersVisibility(collapsable, _collapsed, showClearFilters) {
+		return showClearFilters && collapsable && _collapsed ? 'clear-filters' : 'hide';
+	}
 	_hideVisibility(collapsable, _collapsed) {
 		return collapsable && !_collapsed ? '' : 'hide';
+	}
+	_hideClearFiltersVisibility(collapsable, _collapsed, showClearFilters) {
+		return showClearFilters && collapsable && !_collapsed ? '' : 'hide';
 	}
 	_debounceChildren() {
 		this._debounceJob = Debouncer.debounce(this._debounceJob,
@@ -331,7 +356,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 	_resetWidth(width) {
-		console.log(`width = ${width}`);
 		var d = this.shadowRoot.querySelectorAll('.list-item-container');
 		for(let i = 0; i < d.length; i++) {
 			d[i].style.width = width || "";

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -148,7 +148,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 			 */
 			shrinkwrapMaximumSize: {
 				type: String,
-				value: ""
+				value: ''
 			},
 			/**
 			 * Whether or not to display a clear filters button
@@ -363,7 +363,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	_resetWidth(width) {
 		const d = this.shadowRoot.querySelector('.list-item-container');
 		if (d) {
-			d.style.width = width || "";
+			d.style.width = width || '';
 		}
 	}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -44,27 +44,32 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				padding: 0.15rem;
 			}
 			.clear-filters {
-				display: inline-block'
+				display: inline-block;
+				padding: 0.15rem;
 			}
 			.hide {
 				display: none;
+			}
+			.subtle-button-baseline {
+				height: 30px;
+				margin-top: -2px;
 			}
 		</style>
 			<div class="list-item-container" collapse$=[[_collapsed]]>
 				<slot></slot>
 				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
-					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
+					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button subtle-button-baseline" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 				</div>
 				<div class$="[[_hideClearFiltersVisibility(collapsable, _collapsed, showClearFilters)]]">
-					<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked"></d2l-button-subtle>
+					<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked" class="subtle-button-baseline"></d2l-button-subtle>
 				</div>
 			</div>
 			<slot name="aux-button"></slot>
 			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
-				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false" class="subtle-button-baseline"></d2l-labs-multi-select-list-item>
 			</div>
 			<div class$="[[_clearFiltersVisibility(collapsable, _collapsed, showClearFilters)]]">
-				<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked"></d2l-button-subtle>
+				<d2l-button-subtle text="[[localize('clearFilters')]]" on-click="clearFiltersClicked" class="subtle-button-baseline"></d2l-button-subtle>
 			</div>
 	</template>
 </dom-module>`;
@@ -348,17 +353,17 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 	_updateWidth(width) {
 		if (width > 0) {
-			var d = this.shadowRoot.querySelectorAll('.list-item-container');
-			for(let i = 0; i < d.length; i++) {
-				d[i].style.width = (width + 1) + 'px';
+			const d = this.shadowRoot.querySelector('.list-item-container');
+			if (d) {
+				d.style.width = (width + 1) + 'px';
 			}
 		}
 	}
 
 	_resetWidth(width) {
-		var d = this.shadowRoot.querySelectorAll('.list-item-container');
-		for(let i = 0; i < d.length; i++) {
-			d[i].style.width = width || "";
+		const d = this.shadowRoot.querySelector('.list-item-container');
+		if (d) {
+			d.style.width = width || "";
 		}
 	}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -320,27 +320,18 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const children = this.getEffectiveChildren();
 		const widthOfListItems = this.shadowRoot.querySelector('.list-item-container').getBoundingClientRect().width;
 		let newHiddenChildren = 0;
-		let widthSet = false;
 
 		for (let i = 0; i < children.length; i++) {
 			const listItem = children[i];
-			childrenWidthTotal += listItem.getBoundingClientRect().width;
-			if (childrenWidthTotal > widthOfListItems) {
-				if (this.shrinkwrap) {
-					let desiredWidth = 0;
-					for (let j = 0; j < i; j++) {
-						desiredWidth += children[j].getBoundingClientRect().width;
-					}
-					this.shadowRoot.querySelector('.list-item-container').style['max-width'] = `${desiredWidth}px`;
-					widthSet = true;
-				}
-
+			const childWidth = listItem.getBoundingClientRect().width;
+			if (childrenWidthTotal + childWidth > widthOfListItems) {
 				newHiddenChildren = children.length - i;
 				break;
 			}
+			childrenWidthTotal += childWidth;
 		}
 
-		if (!widthSet && this.shrinkwrap) {
+		if (this.shrinkwrap) {
 			this.shadowRoot.querySelector('.list-item-container').style['max-width'] = `${childrenWidthTotal}px`;
 		}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -170,7 +170,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 	_getClearListText() {
-		return this.clearListButtonText || localize('clearList');
+		return this.clearListButtonText || this.localize('clearList');
 	}
 
 	clearListClicked() {


### PR DESCRIPTION
**TODO: Bump Package Version**

Added a couple features requested by our designer:
(1) The ability to shrink the filter row so that the "+X more" button appears next to the filters instead of at the end of the space
(2) The ability to integrate a "Clear List" button in-line with the list options

These are both optional, and are controlled by the following properties:

Shrinkwrap (boolean) - If this is excluded, all shrinkwrapping functionality is disabled.

showClearList (boolean) - If this is true, then the "clear filters" button appears.  Clicking this dispatches the event `d2l-multi-select-list-clear-filters-clicked` which must be handled by the parent to perform filter clearing.

clearListButtonText (string) - Provides the capability to customize the text displayed on the clear button

Old:
![image](https://user-images.githubusercontent.com/60416666/94585259-5fe87180-0245-11eb-8703-c15b98aab25a.png)

With Shrinkwrap enabled:
![image](https://user-images.githubusercontent.com/60416666/94585116-2ca5e280-0245-11eb-8936-f276f0655a2b.png)

Linked PRs:
- [ ] Facet Filter Sort https://github.com/BrightspaceUILabs/facet-filter-sort/pull/69
- [ ] Folio-app (not yet created)
