### PR TITLE
Actual Shrinkwrap fix for Safari

### DIFF
--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -158,6 +158,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 	constructor() {
 		super();
+		this.firstRender = true;
 		this._onListItemDeleted = this._onListItemDeleted.bind(this);
 		this._debounceChildren = this._debounceChildren.bind(this);
 	}
@@ -314,13 +315,13 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
-		if (this.shrinkwrap) {
+		if (this.shrinkwrap && !this.firstRender) {
 			container.style.maxWidth = 'unset';
 		}
 
 		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
-		const widthOfListItems = 1000;//container.getBoundingClientRect().width;
+		const widthOfListItems = container.getBoundingClientRect().width;
 		let newHiddenChildren = 0;
 
 		for (let i = 0; i < children.length; i++) {
@@ -342,6 +343,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this._handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren);
 
 		this.hiddenChildren = newHiddenChildren;
+		this.firstRender = false;
 	}
 
 	/**

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,7 +315,9 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			container.style.maxWidth = '';
+			if (container.style.maxWidth != '') {
+				container.style.maxWidth = '';
+			}
 		}
 
 		let childrenWidthTotal = 0;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -334,6 +334,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 
 		if (this.shrinkwrap) {
+			//This is a hack required to make it work with Safari
 			setTimeout(() => container.style.maxWidth = `${childrenWidthTotal}px`, 0);
 		}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,6 +315,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
+			console.log('debug debug debug debug');
 			container.style.maxWidth = 'unset';
 		}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,12 +315,12 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			// container.style.maxWidth = '1000px';
+			container.style.maxWidth = 'unset';
 		}
 
 		let childrenWidthTotal = 0;
 		const children = this.getEffectiveChildren();
-		const widthOfListItems = container.getBoundingClientRect().width;
+		const widthOfListItems = 1000;//container.getBoundingClientRect().width;
 		let newHiddenChildren = 0;
 
 		for (let i = 0; i < children.length; i++) {

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,9 +315,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			if (container.style.maxWidth) {
-				container.style.maxWidth = 'unset';
-			}
+			container.style.maxWidth = '';
 		}
 
 		let childrenWidthTotal = 0;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,9 +315,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			if (container.style.maxWidth != '') {
-				container.style.maxWidth = '';
-			}
+			container.style.maxWidth = '1000px';
 		}
 
 		let childrenWidthTotal = 0;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,7 +315,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			container.style.maxWidth = '1000px';
+			// container.style.maxWidth = '1000px';
 		}
 
 		let childrenWidthTotal = 0;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,7 +315,9 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			container.style.maxWidth = 'none';
+			if (container.style.maxWidth) {
+				container.style.maxWidth = 'unset';
+			}
 		}
 
 		let childrenWidthTotal = 0;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -334,7 +334,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 
 		if (this.shrinkwrap) {
-			//This is a hack required to make it work with Safari
+			// Wrapping in a setTimeout is a hack required to make it work with Safari
 			setTimeout(() => container.style.maxWidth = `${childrenWidthTotal}px`, 0);
 		}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -334,7 +334,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 
 		if (this.shrinkwrap) {
-			// container.style.maxWidth = `${childrenWidthTotal}px`;
+			setTimeout(() => container.style.maxWidth = `${childrenWidthTotal}px`, 0);
 		}
 
 		const focusedIndex = children.indexOf(this._currentlyFocusedElement);

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -158,7 +158,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 	constructor() {
 		super();
-		this.firstRender = true;
 		this._onListItemDeleted = this._onListItemDeleted.bind(this);
 		this._debounceChildren = this._debounceChildren.bind(this);
 	}
@@ -315,7 +314,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
-		if (this.shrinkwrap && !this.firstRender) {
+		if (this.shrinkwrap) {
 			container.style.maxWidth = 'unset';
 		}
 
@@ -335,7 +334,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 
 		if (this.shrinkwrap) {
-			container.style.maxWidth = `${childrenWidthTotal}px`;
+			// container.style.maxWidth = `${childrenWidthTotal}px`;
 		}
 
 		const focusedIndex = children.indexOf(this._currentlyFocusedElement);
@@ -343,7 +342,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this._handleFocusChangeOnResize(focusedIndex, hiddenIndex, newHiddenChildren);
 
 		this.hiddenChildren = newHiddenChildren;
-		this.firstRender = false;
 	}
 
 	/**

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,7 +315,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			// container.style.maxWidth = 'unset';
+			container.style.maxWidth = 'none';
 		}
 
 		let childrenWidthTotal = 0;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -315,8 +315,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		const container = this.shadowRoot.querySelector('.list-item-container');
 
 		if (this.shrinkwrap) {
-			console.log('debug debug debug debug');
-			container.style.maxWidth = 'unset';
+			// container.style.maxWidth = 'unset';
 		}
 
 		let childrenWidthTotal = 0;


### PR DESCRIPTION
The issue seemed to be that Safari didn't like setting the maxWidth twice in the same render method.  Adding a timeout to desync these a bit fixed the issue without significantly impacting performance in other browsers.