### PR TITLE
Updates to fix Firefox behavior

### DIFF
--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -40,6 +40,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: block;
 			}
 			.aux-button {
+				height: 30px;
 				display: inline-block;
 				padding: 0.15rem;
 			}
@@ -337,8 +338,8 @@ class D2LMultiSelectList extends mixinBehaviors(
 		if (this.shrinkwrap) {
 			// Wrapping in a setTimeout is a hack required to make it work with Safari
 			setTimeout(() => {
-				container.style.maxWidth = `${childrenWidthTotal}px`
-				container.style.minWidth = `${childrenWidthTotal}px`
+				container.style.maxWidth = `${childrenWidthTotal}px`;
+				container.style.minWidth = `${childrenWidthTotal}px`;
 			}, 0);
 		}
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -36,18 +36,17 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			}
 
 			.list-item-container > ::slotted(d2l-labs-multi-select-list-item) {
-				padding: 0.35rem 0.15rem;
+				padding: 0.15rem;
 				display: block;
 			}
 			.aux-button {
 				display: inline-block;
-				padding: 0.35rem 0.15rem;
+				padding: 0.15rem;
 			}
 			.hide {
 				display: none;
 			}
 			d2l-button-subtle {
-				height: 30px;
 				margin-left: 0.15rem;
 				margin-right: 0.15rem;
 			}
@@ -317,6 +316,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 		if (this.shrinkwrap) {
 			container.style.maxWidth = 'unset';
+			container.style.minWidth = 'unset';
 		}
 
 		let childrenWidthTotal = 0;
@@ -336,7 +336,10 @@ class D2LMultiSelectList extends mixinBehaviors(
 
 		if (this.shrinkwrap) {
 			// Wrapping in a setTimeout is a hack required to make it work with Safari
-			setTimeout(() => container.style.maxWidth = `${childrenWidthTotal}px`, 0);
+			setTimeout(() => {
+				container.style.maxWidth = `${childrenWidthTotal}px`
+				container.style.minWidth = `${childrenWidthTotal}px`
+			}, 0);
 		}
 
 		const focusedIndex = children.indexOf(this._currentlyFocusedElement);


### PR DESCRIPTION
Had to do two things here:

1. Had to remove the vertical margins.  This unfortunately makes the "Hide" and "Clear Filters" buttons unable to be centered if we don't want some vertical overlap.
2. Had to add a minimum width as well as maximum (setting just width did not work)

Chrome:
![image](https://user-images.githubusercontent.com/60416666/95109215-e8fa1f80-0701-11eb-9bae-ac5ca38a641d.png)
![image](https://user-images.githubusercontent.com/60416666/95109243-f4e5e180-0701-11eb-9890-b617fba8a8b4.png)

Firefox:
![image](https://user-images.githubusercontent.com/60416666/95109287-03cc9400-0702-11eb-86bc-957f8e69f19c.png)
![image](https://user-images.githubusercontent.com/60416666/95109303-0b8c3880-0702-11eb-85eb-f8fa8213713b.png)
