### PR TITLE
fixing resolution of dependencies

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../multi-select-input.js';
 			import '../multi-select-input-text.js';
 			import '../multi-select-list.js';

--- a/demo/index_custom_style.html
+++ b/demo/index_custom_style.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../multi-select-list.js';
 			import '../multi-select-list-item.js';
 		</script>


### PR DESCRIPTION
I couldn't get the demos working without this change. It was loading some core dependencies from `/components/@brightspace-ui/core` and some from `/node_modules/@brightspace-ui/core` which resulted in duplicate files getting imported and duplicate web component registrations.