### PR TITLE
US114403 - Adjust how tab indexes are added

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -65,7 +65,22 @@
 					</d2l-labs-multi-select-list>
 				</template>
 			</d2l-demo-snippet>
-			<h3>d2l-labs-multi-select-list collapsable</h3>
+			<h3>d2l-labs-multi-select-list (unrelated hidden children)</h3>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-labs-multi-select-list autoremove>
+						<div style="display: none;"></div>
+						<span style="display: none;"></span>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 0"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 1"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 2"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 3"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 4"></d2l-labs-multi-select-list-item>
+						<d2l-labs-multi-select-list-item deletable="" text="List item 5"></d2l-labs-multi-select-list-item>
+					</d2l-labs-multi-select-list>
+				</template>
+			</d2l-demo-snippet>
+			<h3>d2l-labs-multi-select-list (collapsable)</h3>
 			<d2l-demo-snippet>
 				<template>
 					<d2l-labs-multi-select-list collapsable autoremove>

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -48,17 +48,17 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: none;
 			}
 		</style>
-			<div class="list-item-container" collapse$=[[_collapsed]]>
-				<slot id="item-slot" on-slotchange="_onSlotChange"></slot>
-				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
-					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
-					<slot name="aux-button"></slot>
-				</div>
+		<div class="list-item-container" collapse$=[[_collapsed]]>
+			<slot id="item-slot" on-slotchange="_onSlotChange"></slot>
+			<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
+				<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
+				<slot name="aux-button"></slot>
+			</div>
 
-			</div>
-			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
-				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
-			</div>
+		</div>
+		<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
+			<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
+		</div>
 	</template>
 </dom-module>`;
 

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -49,12 +49,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			}
 		</style>
 			<div class="list-item-container" collapse$=[[_collapsed]]>
-				<slot></slot>
+				<slot id="item-slot" on-slotchange="_onSlotChanged"></slot>
 				<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 					<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 					<slot name="aux-button"></slot>
 				</div>
-
 			</div>
 			<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
 				<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
@@ -137,7 +136,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		if (this._currentlyFocusedElement === null) {
 			this._currentlyFocusedElement = item;
 		}
-		this.getEffectiveChildren()[0].tabIndex = 0;
+
 		this.dispatchEvent(new CustomEvent(
 			'd2l-labs-multi-select-list-item-added',
 			{ bubbles: true, composed: true, detail: { value: item.text } }
@@ -162,20 +161,10 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this.setAttribute('role', 'list');
 
 		afterNextRender(this, function() {
-			const listItems = this.getEffectiveChildren();
-			// Set tabindex to allow component to be focusable, and set role on list items
-			if (listItems.length) {
-				listItems[0].tabIndex = 0;
-				this._currentlyFocusedElement = listItems[0];
-				listItems.forEach(function(listItem) {
-					listItem.setAttribute('role', 'listitem');
-				});
-			}
-
 			this.addEventListener('d2l-labs-multi-select-list-item-deleted', this._onListItemDeleted);
-			this.addEventListener('focus', this._onListItemFocus, true);
 			this.addEventListener('keydown', this._onKeyDown);
 		}.bind(this));
+
 		if (this.collapsable) {
 			this._expandCollapse();
 		}
@@ -184,7 +173,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.removeEventListener('d2l-labs-multi-select-list-item-deleted', this._onListItemDeleted);
-		this.removeEventListener('focus', this._onListItemFocus, true);
 		this.removeEventListener('keydown', this._onKeyDown);
 		if (this.observer) this.observer.disconnect();
 		if (this._nodeObserver) this._nodeObserver.disconnect();
@@ -285,12 +273,6 @@ class D2LMultiSelectList extends mixinBehaviors(
 		}
 	}
 
-	_onListItemFocus(event) {
-		this._currentlyFocusedElement.tabIndex = -1;
-		this._currentlyFocusedElement = event.composedPath()[0];
-		this._currentlyFocusedElement.tabIndex = 0;
-	}
-
 	_onShowButtonKeyDown(event) {
 		const { ENTER, SPACE } = this._keyCodes;
 		const { keyCode } = event;
@@ -313,6 +295,27 @@ class D2LMultiSelectList extends mixinBehaviors(
 			event.stopPropagation();
 			this._expandCollapse();
 		}
+	}
+
+	_onSlotChanged() {
+		afterNextRender(this, () => {
+			let children = this.shadowRoot.querySelector('#item-slot').assignedNodes({ flatten: true });
+
+			children = children.filter(child =>
+				child &&
+				child.nodeType === Node.ELEMENT_NODE &&
+				child.tagName === 'D2L-LABS-MULTI-SELECT-LIST-ITEM'
+			);
+
+			// Set tabindex to allow component to be focusable, and set role on list items
+			if (children.length > 0) {
+				children[0].tabIndex = 0;
+				this._currentlyFocusedElement = children[0];
+				children.forEach(function(listItem) {
+					listItem.setAttribute('role', 'listitem');
+				});
+			}
+		});
 	}
 
 	_showMoreVisibility(collapsable, _collapsed, hiddenChildren) {
@@ -343,4 +346,5 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 }
+
 customElements.define(D2LMultiSelectList.is, D2LMultiSelectList);

--- a/test/multi-select-list.html
+++ b/test/multi-select-list.html
@@ -1,173 +1,185 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-labs-multi-select-list test</title>
-		<script src="/node_modules/@babel/polyfill/browser.js"></script>
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="/node_modules/wct-browser-legacy/browser.js"></script>
-	</head>
-	<body>
-		<test-fixture id="basic">
-			<template>
-				<d2l-labs-multi-select-list autoremove>
-					<d2l-labs-multi-select-list-item id="item0" deletable text="item0"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item1" deletable text="item1"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item2" deletable text="item2"></d2l-labs-multi-select-list-item>
-				</d2l-labs-multi-select-list>
-			</template>
-		</test-fixture>
-		<test-fixture id="collapsable">
-			<template>
-				<d2l-labs-multi-select-list collapsable autoremove style="max-width: 500px;">
-					<d2l-labs-multi-select-list-item id="item0" deletable text="item0"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item1" deletable text="item1"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item2" deletable text="item2"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item3" deletable text="item3"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item4" deletable text="item4"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item5" deletable text="item5"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item6" deletable text="item6"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item7" deletable text="item7"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item8" deletable text="item8"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item9" deletable text="item9"></d2l-labs-multi-select-list-item>
-					<d2l-labs-multi-select-list-item id="item10" deletable text="item10"></d2l-labs-multi-select-list-item>
-				</d2l-labs-multi-select-list>
-			</template>
-		</test-fixture>
-		<script type="module">
-			import '@polymer/iron-test-helpers/mock-interactions.js';
-			import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
-			import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-			import { flush } from '@polymer/polymer/lib/utils/flush.js';
-			import '../multi-select-list.js';
-			import '../multi-select-list-item.js';
-			describe('<d2l-labs-multi-select-list>', function() {
-				let listFixture;
-				const _keyCodes = { BACKSPACE: 8, DELETE: 46, ENTER: 13, SPACE: 32 };
 
-				describe('basic', function() {
-					beforeEach(function(done) {
-						listFixture = fixture('basic');
-						afterNextRender(listFixture, done);
-					});
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+	<title>d2l-labs-multi-select-list test</title>
+	<script src="/node_modules/@babel/polyfill/browser.js"></script>
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+	<script src="/node_modules/wct-browser-legacy/browser.js"></script>
+</head>
 
-					it('should render all list items', function() {
-						expect(listFixture.children.length).to.equal(3);
-					});
+<body>
+	<test-fixture id="basic">
+		<template>
+			<d2l-labs-multi-select-list autoremove>
+				<!-- unrelated hidden children -->
+				<div style="display: none;"></div>
+				<span style="display: none;"></span>
+				<d2l-labs-multi-select-list-item id="item0" deletable text="item0"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item1" deletable text="item1"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item2" deletable text="item2"></d2l-labs-multi-select-list-item>
+			</d2l-labs-multi-select-list>
+		</template>
+	</test-fixture>
+	<test-fixture id="collapsable">
+		<template>
+			<d2l-labs-multi-select-list collapsable autoremove style="max-width: 500px;">
+				<!-- unrelated hidden children -->
+				<div style="display: none;"></div>
+				<span style="display: none;"></span>
+				<d2l-labs-multi-select-list-item id="item0" deletable text="item0"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item1" deletable text="item1"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item2" deletable text="item2"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item3" deletable text="item3"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item4" deletable text="item4"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item5" deletable text="item5"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item6" deletable text="item6"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item7" deletable text="item7"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item8" deletable text="item8"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item9" deletable text="item9"></d2l-labs-multi-select-list-item>
+				<d2l-labs-multi-select-list-item id="item10" deletable text="item10"></d2l-labs-multi-select-list-item>
+			</d2l-labs-multi-select-list>
+		</template>
+	</test-fixture>
+	<script type="module">
+		import '@polymer/iron-test-helpers/mock-interactions.js';
+		import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
+		import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+		import { flush } from '@polymer/polymer/lib/utils/flush.js';
+		import '../multi-select-list.js';
+		import '../multi-select-list-item.js';
+		describe('<d2l-labs-multi-select-list>', function() {
+			let listFixture;
+			const _keyCodes = { BACKSPACE: 8, DELETE: 46, ENTER: 13, SPACE: 32 };
 
-					it('should delete the item when the icon is clicked', function() {
-						let item = document.getElementById('item0');
-						expect(item).to.not.be.null;
+			describe('basic', function() {
+				beforeEach(function(done) {
+					listFixture = fixture('basic');
+					afterNextRender(listFixture, done);
+				});
 
-						const itemShadowRoot = item.shadowRoot;
-						const deleteIcon = itemShadowRoot.querySelector('d2l-icon');
-						MockInteractions.tap(deleteIcon);
+				it('should render all list items', function() {
+					expect(listFixture._children.length).to.equal(3);
+				});
 
+				it('should delete the item when the icon is clicked', function(done) {
+					let item = document.getElementById('item0');
+					expect(item).to.not.be.null;
+
+					const itemShadowRoot = item.shadowRoot;
+					const deleteIcon = itemShadowRoot.querySelector('d2l-icon');
+					MockInteractions.tap(deleteIcon);
+
+					afterNextRender(listFixture, function() {
 						item = document.getElementById('item0');
-						expect(listFixture.children.length).to.equal(2);
+						expect(listFixture._children.length).to.equal(2);
 						expect(item).to.be.null;
-					});
-
-					describe('keyboard-behavior', function() {
-						let item0, item1, item2;
-						beforeEach(function(done) {
-							afterNextRender(listFixture, function() {
-								item0 = document.getElementById('item0');
-								item1 = document.getElementById('item1');
-								item2 = document.getElementById('item2');
-								done();
-							});
-						});
-
-						function testDeleteAndFocus(itemToDelete, expectedFocusItem, keyCode, done) {
-							MockInteractions.keyDownOn(itemToDelete, keyCode);
-
-							afterNextRender(listFixture, function() {
-								expect(document.getElementById(itemToDelete.id)).to.be.null;
-								expect(getComposedActiveElement()).to.equal(expectedFocusItem);
-								done();
-							});
-						}
-
-						it('should delete the item when Backspace is pressed and switch focus to the previous item', function(done) {
-							testDeleteAndFocus(item1, item0, _keyCodes.BACKSPACE, done);
-						});
-
-						it('should delete the item when Backspace is pressed and switch focus to the next item when it is the first of the list', function(done) {
-							testDeleteAndFocus(item0, item1, _keyCodes.BACKSPACE, done);
-						});
-
-						it('should delete the item when Delete is pressed and switch focus to the next item', function(done) {
-							testDeleteAndFocus(item1, item2, _keyCodes.DELETE, done);
-						});
-
-						it('should delete the item when Delete is pressed and switch focus to the previous item when it is the last item', function(done) {
-							testDeleteAndFocus(item2, item1, _keyCodes.DELETE, done);
-						});
-
-						it('should switch tabindex when moving focusing different items', function() {
-							expect(document.getElementById(item0.id).tabIndex).to.equal(0);
-							expect(document.getElementById(item1.id).tabIndex).to.equal(-1);
-							expect(document.getElementById(item2.id).tabIndex).to.equal(-1);
-
-							MockInteractions.focus(item1);
-							flush();
-
-							expect(document.getElementById(item0.id).tabIndex).to.equal(-1);
-							expect(document.getElementById(item1.id).tabIndex).to.equal(0);
-							expect(document.getElementById(item2.id).tabIndex).to.equal(-1);
-						});
+						done();
 					});
 				});
 
-				describe('collapsable', function() {
-					let showButton, hideButton;
+				describe('keyboard-behavior', function() {
+					let item0, item1, item2;
 					beforeEach(function(done) {
-						listFixture = fixture('collapsable');
-						showButton = listFixture.shadowRoot.querySelector('.show-button');
-						hideButton = listFixture.shadowRoot.querySelector('.hide-button');
-						afterNextRender(listFixture, done);
+						afterNextRender(listFixture, function() {
+							item0 = document.getElementById('item0');
+							item1 = document.getElementById('item1');
+							item2 = document.getElementById('item2');
+							done();
+						});
 					});
 
-					it('should render only items that fit', function() {
-						// note: this is related to the max-width being set by the fixture
-						expect(listFixture.hiddenChildren).to.equal(6);
+					function testDeleteAndFocus(itemToDelete, expectedFocusItem, keyCode, done) {
+						MockInteractions.keyDownOn(itemToDelete, keyCode);
+
+						afterNextRender(listFixture, function() {
+							expect(document.getElementById(itemToDelete.id)).to.be.null;
+							expect(getComposedActiveElement()).to.equal(expectedFocusItem);
+							done();
+						});
+					}
+
+					it('should delete the item when Backspace is pressed and switch focus to the previous item', function(done) {
+						testDeleteAndFocus(item1, item0, _keyCodes.BACKSPACE, done);
 					});
 
-					it('should expand/collapse the list when show/hide buttons are clicked', function() {
+					it('should delete the item when Backspace is pressed and switch focus to the next item when it is the first of the list', function(done) {
+						testDeleteAndFocus(item0, item1, _keyCodes.BACKSPACE, done);
+					});
+
+					it('should delete the item when Delete is pressed and switch focus to the next item', function(done) {
+						testDeleteAndFocus(item1, item2, _keyCodes.DELETE, done);
+					});
+
+					it('should delete the item when Delete is pressed and switch focus to the previous item when it is the last item', function(done) {
+						testDeleteAndFocus(item2, item1, _keyCodes.DELETE, done);
+					});
+
+					it('should switch tabindex when moving focusing different items', function() {
+						expect(document.getElementById(item0.id).tabIndex).to.equal(0);
+						expect(document.getElementById(item1.id).tabIndex).to.equal(-1);
+						expect(document.getElementById(item2.id).tabIndex).to.equal(-1);
+
+						MockInteractions.focus(item1);
+						flush();
+
+						expect(document.getElementById(item0.id).tabIndex).to.equal(-1);
+						expect(document.getElementById(item1.id).tabIndex).to.equal(0);
+						expect(document.getElementById(item2.id).tabIndex).to.equal(-1);
+					});
+				});
+			});
+
+			describe('collapsable', function() {
+				let showButton, hideButton;
+				beforeEach(function(done) {
+					listFixture = fixture('collapsable');
+					showButton = listFixture.shadowRoot.querySelector('.show-button');
+					hideButton = listFixture.shadowRoot.querySelector('.hide-button');
+					afterNextRender(listFixture, done);
+				});
+
+				it('should render only items that fit', function() {
+					// note: this is related to the max-width being set by the fixture
+					expect(listFixture.hiddenChildren).to.equal(6);
+				});
+
+				it('should expand/collapse the list when show/hide buttons are clicked', function() {
+					expect(listFixture._collapsed).to.be.true;
+
+					MockInteractions.tap(showButton);
+					expect(listFixture._collapsed).to.be.false;
+
+					MockInteractions.tap(hideButton);
+					expect(listFixture._collapsed).to.be.true;
+				});
+
+				describe('keyboard-behavior', function() {
+					it('should expand/collapse list when enter is pressed on show/hide toggle', function() {
 						expect(listFixture._collapsed).to.be.true;
 
-						MockInteractions.tap(showButton);
+						MockInteractions.keyDownOn(showButton, _keyCodes.ENTER);
 						expect(listFixture._collapsed).to.be.false;
 
 						MockInteractions.tap(hideButton);
 						expect(listFixture._collapsed).to.be.true;
 					});
 
-					describe('keyboard-behavior', function() {
-						it('should expand/collapse list when enter is pressed on show/hide toggle', function() {
-							expect(listFixture._collapsed).to.be.true;
+					it('should expand/collapse list when space is pressed on show/hide toggle', function() {
+						expect(listFixture._collapsed).to.be.true;
 
-							MockInteractions.keyDownOn(showButton, _keyCodes.ENTER);
-							expect(listFixture._collapsed).to.be.false;
+						MockInteractions.keyUpOn(showButton, _keyCodes.SPACE);
+						expect(listFixture._collapsed).to.be.false;
 
-							MockInteractions.tap(hideButton);
-							expect(listFixture._collapsed).to.be.true;
-						});
-
-						it('should expand/collapse list when space is pressed on show/hide toggle', function() {
-							expect(listFixture._collapsed).to.be.true;
-
-							MockInteractions.keyUpOn(showButton, _keyCodes.SPACE);
-							expect(listFixture._collapsed).to.be.false;
-
-							MockInteractions.tap(hideButton);
-							expect(listFixture._collapsed).to.be.true;
-						});
+						MockInteractions.tap(hideButton);
+						expect(listFixture._collapsed).to.be.true;
 					});
 				});
 			});
-		</script>
-	</body>
+		});
+	</script>
+</body>
+
 </html>


### PR DESCRIPTION
Adjust handing of tab index to better deal with issues for polymer type elements, specifically `<dom-repeat>`. This adds logic for ignoring unrelated elements nested under a`d2l-multi-select-list`. Tested in context with rubrics as well as with demo page in **Firefox**, **Chrome** and **Edge**.

Recommend viewing with [white-space diff off](https://github.com/BrightspaceUILabs/multi-select/pull/93/files?w=1). 

