### PR TITLE
US114403 - Fix-up accessibility of list

### DIFF
--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -48,13 +48,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: none;
 			}
 		</style>
-		<div class="list-item-container" collapse$=[[_collapsed]]>
-			<slot id="item-slot" on-slotchange="_onSlotChange"></slot>
+		<div class="list-item-container" role="list" collapse$=[[_collapsed]]>
+			<slot role="presentation" on-slotchange="_onSlotChange"></slot>
 			<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 				<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 				<slot name="aux-button"></slot>
 			</div>
-
 		</div>
 		<div class$="[[_showMoreVisibility(collapsable, _collapsed, hiddenChildren)]]">
 			<d2l-labs-multi-select-list-item text="[[localize('hiddenChildren', 'num', hiddenChildren)]]" role="button" class="show-button" on-click="_expandCollapse" on-keyup="_onShowButtonKeyUp" on-keydown="_onShowButtonKeyDown" aria-expanded="false"></d2l-labs-multi-select-list-item>
@@ -168,7 +167,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 		this.observer.observe(this);
 		this._nodeObserver = new FlattenedNodesObserver(this, this._debounceChildren);
 
-		this.setAttribute('role', 'list');
+		this.setAttribute('role', 'application');
 
 		afterNextRender(this, function() {
 			this.addEventListener('d2l-labs-multi-select-list-item-deleted', this._onListItemDeleted);

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -48,7 +48,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 				display: none;
 			}
 		</style>
-		<div class="list-item-container" role="list" collapse$=[[_collapsed]]>
+		<div class="list-item-container" aria-label$="[[description]]" role="list" collapse$=[[_collapsed]]>
 			<slot role="presentation" on-slotchange="_onSlotChange"></slot>
 			<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 				<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
@@ -130,6 +130,11 @@ class D2LMultiSelectList extends mixinBehaviors(
 			_children: {
 				type: Array,
 				attribute: false
+			},
+			description: {
+				type: String,
+				value: null,
+				reflectToAttribute: true
 			}
 		};
 	}

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -49,7 +49,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-list">
 			}
 		</style>
 		<div class="list-item-container" aria-label$="[[description]]" role="list" collapse$=[[_collapsed]]>
-			<slot role="presentation" on-slotchange="_onSlotChange"></slot>
+			<slot on-slotchange="_onSlotChange"></slot>
 			<div class$="[[_hideVisibility(collapsable, _collapsed)]]">
 				<d2l-button-subtle text="[[localize('hide')]]" role="button" class="hide-button" on-click="_expandCollapse" aria-expanded="true"></d2l-button-subtle>
 				<slot name="aux-button"></slot>


### PR DESCRIPTION
This allows proper navigation of the list of items when screen readers are enabled. This also adds an optional `description` attribute for use by screen readers.

Tested in **Firefox**, **Chrome** and **Edge** with **NVDA**.