### PR TITLE
Add files to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "access": "public"
   },
   "files": [
+    "./lang/**",
+    "attribute-picker.js",
+    "localization.js",
     "localize-behavior.js",
     "multi-select-input-text.js",
     "multi-select-input.js",


### PR DESCRIPTION
Adds newly added lang and component files to the package.json files list. 
For reference, this list is the include list of files to be downloaded as an npm dependency - The tests and screenshots, etc aren't necessary and can be ignored.