### PR TITLE
US132870  Accept Named Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ An autocompleting dropdown to choose one or more new or pre-existing attributes 
 |--|--|--|
 | allow-freeform | Boolean | When enabled, the user can manually type any attribute they wish. If false, they must select from the dropdown. |
 | aria-label | String | Required. When true, the autocomplete dropdown will not be displayed to the user. |
-| attribute-list | Array |  An array of strings representing the attributes currently selected in the picker. |
-| assignable-attributes | Array | An array of strings available in the dropdown list. |
+| attribute-list | Array |  An array of string/value pairs representing the attributes currently selected in the picker (eg `[{"name":"shown to user","value":"sent in event"}]`). Only the values are sent in events and the string names are otherwise ignored. |
+| assignable-attributes | Array | An array of string/value pairs, just like _attribute-list_, available in the dropdown list. |
 | hide-dropdown | Boolean | When enabled, the autocomplete dropdown will not be displayed to the user. |
 | limit | Number | The maximum length of attribute-list permitted. |
 

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -193,14 +193,14 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 					?hidden="${!this._inputFocused || this.hideDropdown || availableAttributes.length === 0}"
 					class="d2l-attribute-list">
 
-					${availableAttributes.map((item) => html`
+					${availableAttributes.map((item, listIndex) => html`
 						<li id="attribute-dropdown-list-item-${listIndex}"
 							aria-label="${this.localize('picker_add_value', 'value', item)}"
 							aria-selected="${this._dropdownIndex === listIndex ? true : false}"
 							role="option"
 							class="d2l-attribute-picker-li ${this._dropdownIndex === listIndex ? 'd2l-selected' : ''}"
 							.text="${item}"
-							.index=${index}
+							.index=${listIndex}
 							@mouseover="${this._onListItemMouseOver}"
 							@mousedown="${this._onListItemTapped}">
 							${item.name}

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -282,7 +282,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			composed: true,
 			detail: {
 				// The only thing people care to get from us is the list of values and not their names!
-				attributeList: this.attributeList.map(a => a.value)
+				attributeList: this.attributeList
 			}
 		}));
 	}

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -425,7 +425,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 					const matchedIndex = this.assignableAttributes.findIndex(a => a.name.toLowerCase() === comparableAttribute);
 					this.addAttribute(matchedIndex >= 0 ? this.assignableAttributes[matchedIndex] : {
 						name: trimmedAttribute,
-						value: trimmedAttribute // this is unlikely to ever be right but what else can we do?!
+						value: trimmedAttribute
 					});
 				}
 				this._updateDropdownFocus();

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -222,9 +222,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		}
 	}
 
-	//Returns true or false depending on if the attribute was successfully added. Fires the d2l-attribute-limit-reached event if necessary.
-	// TODO  Is there a reason why this function is async?
-	async addAttribute(newAttribute) {
+	// Returns true or false depending on if the attribute was successfully added. Fires the d2l-attribute-limit-reached event if necessary.
+	addAttribute(newAttribute) {
 		if (!newAttribute || this.attributeList.findIndex(attribute => attribute.name === newAttribute.name) >= 0) {
 			return false;
 		}
@@ -244,15 +243,16 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		this._text = '';
 
 		//Wait until we can get the full list of available list items after clearing the text
-		await this.updateComplete;
-		const list = this.shadowRoot.querySelectorAll('li');
+		this.updateComplete.then(() => {
+			const list = this.shadowRoot.querySelectorAll('li');
 
-		//If we removed the final index of the list, move our index back to compensate
-		if (this._dropdownIndex > -1 && this._dropdownIndex > list.length - 1) {
-			this._dropdownIndex --;
-		}
+			//If we removed the final index of the list, move our index back to compensate
+			if (this._dropdownIndex > -1 && this._dropdownIndex > list.length - 1) {
+				this._dropdownIndex --;
+			}
 
-		this._dispatchAttributeChangedEvent();
+			this._dispatchAttributeChangedEvent();
+		});
 
 		return true;
 	}

--- a/demo/attribute-picker.html
+++ b/demo/attribute-picker.html
@@ -18,32 +18,36 @@
 		<d2l-demo-snippet>
 			<d2l-labs-attribute-picker aria-label="attributes"
 				allow-freeform
-				attribute-list='["one","two","three"]'
-				assignable-attributes='["one","two","three","four","five","six"]'></d2l-labs-attribute-picker>
+				attribute-list='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3}]'
+				assignable-attributes='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6}]'
+			></d2l-labs-attribute-picker>
 		</d2l-demo-snippet>
 
 		<h2>d2l-labs-attribute-picker - Allow Freeform disabled</h2>
 		<d2l-demo-snippet>
 			<d2l-labs-attribute-picker aria-label="attributes"
-				attribute-list='["one","two","three"]'
-				assignable-attributes='["one","two","three","four","five","six"]'></d2l-labs-attribute-picker>
+				attribute-list='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3}]'
+				assignable-attributes='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6}]'
+			></d2l-labs-attribute-picker>
 		</d2l-demo-snippet>
 
 		<h2>d2l-labs-attribute-picker - limit of 5</h2>
 		<d2l-demo-snippet>
 			<d2l-labs-attribute-picker aria-label="attributes"
 				allow-freeform
-				attribute-list='["one","two","three"]'
-				assignable-attributes='["one","two","three","four","five","six"]'
-				limit="5"></d2l-labs-attribute-picker>
+				attribute-list='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3}]'
+				assignable-attributes='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6}]'
+				limit="5"
+			></d2l-labs-attribute-picker>
 		</d2l-demo-snippet>
 
 		<h2>d2l-labs-attribute-picker - wrapped</h2>
 		<d2l-demo-snippet style="width:500px;">
 			<d2l-labs-attribute-picker aria-label="attributes"
 				allow-freeform
-				attribute-list='["one","two","three","four","five","six","seven"]'
-				assignable-attributes='["one","two","three","four","five","six","seven"]'></d2l-labs-attribute-picker>
+				attribute-list='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6},{"name":"seven","value":7}]'
+				assignable-attributes='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6},{"name":"seven","value":7}]'
+			></d2l-labs-attribute-picker>
 		</d2l-demo-snippet>
 	</d2l-demo-page>
 	</body>

--- a/multi-select-input.js
+++ b/multi-select-input.js
@@ -24,7 +24,7 @@ document.head.appendChild($_documentContainer.content);
 /**
  * `<d2l-labs-multi-select-input>`
  * Polymer-based web component for D2L multi-select-input
- * @demo demo/index.hmtl
+ * @demo demo/index.html
  */
 class D2LMultiSelectInput extends PolymerElement {
 	static get properties() {

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -409,7 +409,6 @@ describe('attribute-picker', () => {
 			expect(result.detail.attributeList).to.deep.equal(
 				assignableAttributeList
 					.slice(0, result.detail.attributeList.length)
-					.map(a => a.value)
 			);
 		});
 
@@ -452,9 +451,7 @@ describe('attribute-picker', () => {
 
 			expect(result.detail.attributeList.length).to.equal(2);
 			expect(result.detail.attributeList).to.deep.equal(
-				assignableAttributeList
-					.slice(0, result.detail.attributeList.length)
-					.map(a => a.value)
+				assignableAttributeList.slice(0, result.detail.attributeList.length)
 			);
 		});
 


### PR DESCRIPTION
In order to avoid showing resource IDs to the user, we've modified the multi-select control to accept "named values," so that the data shown to the user is not necessarily the data sent by the control.  There is no "non-named" mode because, if you don't need this feature, you can simply have your names equal your values and it this control will work as it did before.

It's possible to have `assignableAttributes` elements that have the same value but having said elements with the same name will result in undefined behavior.  This was done to make the PR simpler, under the assumption that it's nonsensical for multiple items in the dropdown to have the same name (how would the user distinguish between the two?).

It still broadcasts just an array of the values and not their names, under the assumption that that's the only data clients of this control care about...