### PR TITLE
fix: Dropdown options no longer "blank" using NVDA

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -197,6 +197,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 						<li id="attribute-dropdown-list-item-${listIndex}"
 							aria-label="${this.localize('picker_add_value', 'value', item)}"
 							aria-selected="${this._dropdownIndex === listIndex ? true : false}"
+							role="option"
 							class="d2l-attribute-picker-li ${this._dropdownIndex === listIndex ? 'd2l-selected' : ''}"
 							.text="${item}"
 							.index=${listIndex++}


### PR DESCRIPTION
Fixes issue mentioned in [DE46045](https://rally1.rallydev.com/#/611579333303d/dashboard?detail=%2Fdefect%2F614634769203)

Previously, the options in the `attribute-picker` dropdown would appear as "blank" when focused on (using NVDA). By adding `role="option"`, NVDA now properly reads out the option to the user.