### PR TITLE
fix: DE46112 Editing Attributes Fix

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -349,15 +349,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_onAttributeRemoved(e) {
-		this.attributeList.splice(this.attributeList.indexOf(e.detail.value), 1);
-		this.dispatchEvent(new CustomEvent('d2l-attributes-changed', {
-			bubbles: true,
-			composed: true,
-			detail: {
-				attributeList: this.attributeList
-			}
-		}));
-		this.requestUpdate();
+		this._removeAttributeIndex(this.attributeList.indexOf(e.detail.value));
 	}
 
 	_onInputBlur() {


### PR DESCRIPTION
This solves the issue found in [DE46112](https://rally1.rallydev.com/#/611579333303d/dashboard?detail=%2Fdefect%2F615632406081).

For some reason, the removal of attributes using the `x` was making it so removed attributes would save upon cancelling in enrollment rules. However, removing an attribute using `backspace` or `delete` was working perfectly fine in the same scenario. So to fix the issue and to maintain consistency through both methods, the event handler for clicking the `x` to remove the attribute (`_onAttributeRemoved`) now calls the method that using `backspace` or `delete` call (`_removeAttributeIndex`).