### PR TITLE
fix: DE46226 NVDA repeating every list item in list for each list item

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -155,7 +155,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 		return html`
 		<div role="application" class="d2l-attribute-picker-container ${this._inputFocused ? 'd2l-attribute-picker-container-focused' : ''}">
-			<div class="d2l-attribute-picker-content" aria-live="polite" role="${this.attributeList.length > 0 ? 'list' : ''}">
+			<div class="d2l-attribute-picker-content" role="${this.attributeList.length > 0 ? 'list' : ''}">
 				${this.attributeList.map((item, index) => html`
 					<d2l-labs-multi-select-list-item
 						class="d2l-attribute-picker-attribute"


### PR DESCRIPTION
Fixes the defect found in [DE46226](https://rally1.rallydev.com/#/611579333303d/custom/367300408400?detail=%2Fdefect%2F618271262087).

Removed aria-live politeness because it was causing each list item to be read every time any list item was selected instead of only listing the selected item.