### PR TITLE
fix: check the name and value of attributes when deleting

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -356,12 +356,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_onAttributeRemoved(e) {
-		let index = this.attributeList.map((e) => e.name).indexOf(e.detail.value);
-		if (index === -1) {
-			index = this.attributeList.map((e) => e.value).indexOf(e.detail.value);
-		}
-		if (index !== -1) {
-			this._removeAttributeIndex(index);
+		if (e.target.index !== -1) {
+			this._removeAttributeIndex(e.target.index);
 		}
 	}
 

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -356,7 +356,13 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_onAttributeRemoved(e) {
-		this._removeAttributeIndex(this.attributeList.indexOf(e.detail.value));
+		let index = this.attributeList.map((e) => e.name).indexOf(e.detail.value);
+		if (index === -1) {
+			index = this.attributeList.map((e) => e.value).indexOf(e.detail.value);
+		}
+		if (index !== -1) {
+			this._removeAttributeIndex(index);
+		}
 	}
 
 	_onInputBlur() {


### PR DESCRIPTION
### Context:
[DE46259](https://rally1.rallydev.com/#/?detail=/defect/618604967661&fdp=true)
When attempting to remove an item from the attribute list, we were searching for the index of the item in the list. Since we recently changed items to be stored as {name, value} pairs, we were not finding the item that needed to be removed and thus attempting to remove the item in location -1 (the end of the list).

This pr first searches the names of the attributes for the item to be removed. If not found, we search the values. If neither is found, we do not remove an item from the list.

### Quality:
Tested using discoverdev and local bsi.