### PR TITLE
fix: DE46226 NVDA repeating every list item in list for each list item

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -165,7 +165,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 						@d2l-labs-multi-select-list-item-deleted="${this._onAttributeRemoved}"
 						@blur="${this._onAttributeBlur}"
 						@focus="${this._onAttributeFocus}"
-						@keydown="${this._onAttributeKeydown}">
+						@keydown="${this._onAttributeKeydown}"
+						aria-live="off">
 					</d2l-labs-multi-select-list-item>
 				`)}
 


### PR DESCRIPTION
Fixes the defect [DE46226](https://rally1.rallydev.com/#/611579333303d/dashboard?detail=%2Fdefect%2F618271262087)

The previous fix only partially fixed the issue, aria-live now needed to be explicitly set to off to guarantee that the rest of the list isn't read out.