### PR TITLE
fix: DE46408 Remove Extra Padding from Attribute Picker

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -112,6 +112,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				max-height: 7.8rem;
 				min-height: 0;
 				overflow-y: scroll;
+				padding-left: 0px;
 				text-overflow: ellipsis;
 			}
 

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -112,7 +112,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				max-height: 7.8rem;
 				min-height: 0;
 				overflow-y: scroll;
-				padding-left: 0px;
+				padding-left: 0;
 				text-overflow: ellipsis;
 			}
 


### PR DESCRIPTION
Context for [DE46408](https://rally1.rallydev.com/#/611579333303d/custom/367300408400?detail=%2Fdefect%2F619403966021):

On smaller screens, the extra padding that's given to `ul` elements by default results in the contents inside the dropdown menu being harder to read as they get pushed off screen.