### PR TITLE
Dlockhart/fix axe error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,7 @@ npm install @brightspace-ui-labs/multi-select
 
 ## Usage
 
-Include the [webcomponents.js](http://webcomponents.org/polyfills/) polyfill loader (for browsers who don't natively support web components), then import the appropriate `multi-select` components as needed:
-
-```html
-<head>
-	<script src="node_modules/webcomponentsjs/webcomponents-loader.js"></script>
-</head>
-```
-
-# Components
-
-## `d2l-labs-multi-select-input-text`
+### `d2l-labs-multi-select-input-text`
 
 `d2l-labs-multi-select-input-text` includes a `d2l-input-text` that is hooked up to add items when 'Enter' is pressed.
 **Usage:**
@@ -47,7 +37,7 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) polyfill loa
 </d2l-labs-multi-select-input-text>
 ```
 
-## `d2l-labs-multi-select-input`
+### `d2l-labs-multi-select-input`
 
 You can use your own input component instead by putting it as a child of `d2l-labs-multi-select-input` and setting `slot="input"` on your input element. To add items to the list, call `addItem` with the item text.
 **Usage:**
@@ -66,7 +56,7 @@ button.addEventListener('click', () => {
 })
 ```
 
-## `d2l-labs-attribute-picker`
+### `d2l-labs-attribute-picker`
 
 An autocompleting dropdown to choose one or more new or pre-existing attributes inline.
 **Usage:**
@@ -105,7 +95,7 @@ attributePicker.addEventListener('d2l-attributes-changed', (e) => {
 
 The `d2l-labs-attribute-picker` dispatches the `d2l-attribute-limit-reached` event when the user attempts to enter an attribute greater than the limit. This can be used to send feedback to the user.
 
-## `d2l-labs-multi-select-list-item`
+### `d2l-labs-multi-select-list-item`
 
 `d2l-labs-multi-select-list-item` is a compact representation of information.
 
@@ -126,7 +116,7 @@ Also the following css variables are exposed to clients and can be use to overri
 --d2l-labs-multi-select-list-item-padding-deletable-rtl
 ```
 
-## `d2l-labs-multi-select-list`
+### `d2l-labs-multi-select-list`
 
 `d2l-labs-multi-select-list` wraps a list of items, and provides spacing between the items, as well as keyboard navigation (arrow keys) and handling of item deletion (backspace/delete).
 
@@ -151,12 +141,6 @@ You can opt for a condensed view by adding the `collapsable` attribute, which li
 ## Developing, Testing and Contributing
 
 After cloning the repo, run `npm install` to install dependencies.
-
-If you don't have it already, install the [Polymer CLI](https://www.polymer-project.org/3.0/docs/tools/polymer-cli) globally:
-
-```shell
-npm install -g polymer-cli
-```
 
 Start a [@web/dev-server](https://modern-web.dev/docs/dev-server/overview/) that hosts the demo pages:
 

--- a/demo/attribute-picker.html
+++ b/demo/attribute-picker.html
@@ -2,14 +2,12 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../attribute-picker.js';
 		</script>
 		<title>d2l-labs-attribute-picker</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,13 +2,11 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 		</script>
 		<title>@brightspace-hmc/multi-select</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body>

--- a/demo/multi-select-input-text.html
+++ b/demo/multi-select-input-text.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../multi-select-input-text.js';
@@ -10,7 +9,6 @@
 		</script>
 		<title>d2l-labs-multi-select-input-text</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
 	<body>

--- a/demo/multi-select-input.html
+++ b/demo/multi-select-input.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../multi-select-input.js';
@@ -10,7 +9,6 @@
 		</script>
 		<title>d2l-labs-multi-select-input</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 
 		<style>

--- a/demo/multi-select-list.html
+++ b/demo/multi-select-list.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../multi-select-input.js';
@@ -10,7 +9,6 @@
 		</script>
 		<title>d2l-labs-multi-select-list</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 
 		<custom-style>

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -161,7 +161,7 @@ class MultiSelectList extends RtlMixin(Localizer(LitElement)) {
 		return html`
 		<div class="d2l-list-item-container" role="list" aria-label="${this.description}" ?data-collapsed=${this._collapsed}>
 			<slot @slotchange="${this._onSlotChange}"></slot>
-			<div class="${this._hideVisibility(this.collapsable, this._collapsed, this.hiddenChildren)}">
+			<div class="${this._hideVisibility(this.collapsable, this._collapsed, this.hiddenChildren)}" role="listitem">
 				<d2l-button-subtle text="${this.localize('hide')}" class="d2l-hide-button" @click="${this._expandCollapse}" aria-expanded="true"></d2l-button-subtle>
 				<slot name="aux-button"></slot>
 			</div>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.0.3",
     "@open-wc/testing": "^3.0.3",
-    "@webcomponents/webcomponentsjs": "^2",
     "@web/dev-server": "^0.1.23",
     "@web/test-runner": "^0.13",
     "eslint": "^7",

--- a/test/multi-select-list.test.js
+++ b/test/multi-select-list.test.js
@@ -50,6 +50,11 @@ describe('multi-select-list', () => {
 			await item.updateComplete;
 			await expect(el).to.be.accessible();
 		});
+
+		it('should pass all aXe tests when collapsible', async() => {
+			el = await fixture(collapsableHtml);
+			await expect(el).to.be.accessible();
+		});
 	});
 
 	describe('functionality', () => {


### PR DESCRIPTION
Noticed this aXe error in a downstream project that was using multi-select.

Whenever something has `role="list"`, all children need to be list items. In this case, the "hide" button that gets displayed when collapsible lists overflow wasn't a list item. Semantically... it's debatable whether it should be part of the list or if it should be rendered outside the list like the "+ X more" button. For now though this resolve the immediate issue. 