### PR TITLE
Lit Update Phase 1 changes

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -246,7 +246,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 		//Wait until we can get the full list of available list items after clearing the text
 		this.updateComplete.then(() => {
-			const list = this.shadowRoot.querySelectorAll('li');
+			const list = this.shadowRoot && this.shadowRoot.querySelectorAll('li');
 
 			//If we removed the final index of the list, move our index back to compensate
 			if (this._dropdownIndex > -1 && this._dropdownIndex > list.length - 1) {
@@ -264,7 +264,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_activeAttributeIndexChanged() {
-		const selectedAttributes = this.shadowRoot.querySelectorAll('.d2l-attribute-picker-attribute');
+		const selectedAttributes = this.shadowRoot && this.shadowRoot.querySelectorAll('.d2l-attribute-picker-attribute');
 		if (this._activeAttributeIndex >= 0 && this._activeAttributeIndex < selectedAttributes.length) {
 			selectedAttributes[this._activeAttributeIndex].focus();
 		}
@@ -290,6 +290,9 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_focusAttribute(index) {
+		if (!this.shadowRoot) {
+			return;
+		}
 		const selectedAttributes = this.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');
 		this._activeAttributeIndex = index;
 		selectedAttributes[index].focus();
@@ -315,6 +318,9 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_onAttributeKeydown(e) {
+		if (!this.shadowRoot) {
+			return;
+		}
 		switch (e.keyCode) {
 			case keyCodes.BACKSPACE: {
 				this._removeAttributeIndex(this._activeAttributeIndex);
@@ -374,11 +380,14 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			this._dropdownIndex = -1;
 		}
 		else {
-			this._dropdownIndex = this.shadowRoot.querySelector('li') !== null ? 0 : -1;
+			this._dropdownIndex = this.shadowRoot && this.shadowRoot.querySelector('li') !== null ? 0 : -1;
 		}
 	}
 
 	_onInputKeydown(e) {
+		if (!this.shadowRoot) {
+			return;
+		}
 		switch (e.keyCode) {
 			case keyCodes.ESCAPE: {
 				if (this.allowFreeform) {//Unselect any dropdown item so enter will apply to just the typed text instead
@@ -462,7 +471,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 	_updateDropdownFocus() {
 		this.updateComplete.then(() => {
-			const items = this.shadowRoot.querySelectorAll('li');
+			const items = this.shadowRoot && this.shadowRoot.querySelectorAll('li');
 			if (items.length > 0 && this._dropdownIndex >= 0) {
 				items[this._dropdownIndex].scrollIntoView({ block: 'nearest' });
 			}

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -1,9 +1,9 @@
 import '@brightspace-ui/core/components/button/button-subtle.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { getComposedChildren, isComposedAncestor } from '@brightspace-ui/core/helpers/dom';
+import { getComposedChildren, isComposedAncestor } from '@brightspace-ui/core/helpers/dom.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
-import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus';
+import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 import { Localizer } from './localization.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
@@ -216,6 +216,9 @@ class MultiSelectList extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_getVisibleEffectiveChildren() {
+		if (!this.shadowRoot) {
+			return [];
+		}
 		const children = this._children;
 		const auxButton = (this.collapsable && getComposedChildren(this.shadowRoot.querySelector('.d2l-aux-button'))) || [];
 		const hideButton = (this.collapsable && !this._collapsed && [this.shadowRoot.querySelector('.d2l-hide-button')]) || [];
@@ -368,7 +371,7 @@ class MultiSelectList extends RtlMixin(Localizer(LitElement)) {
 
 	async _updateChildren() {
 		await this.updateComplete;
-		if (!this.collapsable) {
+		if (!this.collapsable || !this.shadowRoot) {
 			return;
 		}
 		let childrenWidthTotal = 0;


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare this repo for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away.
Non-breaking change checklist:
- [x] Add missing `.js` extensions for lit-html or lit-element imports
- [x] `await requestUpdate` -> `await elem.updateComplete`
- [x] add non-null checks to shadowRoot accesses (not including test files)
- [x] ensure `undefined` is not passed into unsafeHTML calls
- [x] remove dynamic code from inside  `<template>` tags (Lit files only)
- [x] remove any dependencies on old Lit versions
- [x] audit `ifDefined` usages for null parameters
For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.