### PR TITLE
Lit 2.0 Phase 2: Breaking Changes - DO NOT MERGE

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "stylelint": "^14"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "@polymer/polymer": "^3",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "lit-element": "^3"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^3.0.3",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1.23",
     "@web/test-runner": "^0.13",
     "eslint": "^7",
@@ -50,6 +50,7 @@
   "dependencies": {
     "@brightspace-ui/core": "^1",
     "@polymer/polymer": "^3",
-    "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2"
+    "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
+    "lit-element": "^3"
   }
 }

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -40,7 +40,7 @@ describe('attribute-picker', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
-			const el = await fixture(html`<d2l-labs-attribute-picker></d2l-labs-attribute-picker>`);
+			const el = await fixture(html`<d2l-labs-attribute-picker aria-label="attributes"></d2l-labs-attribute-picker>`);
 			await expect(el).to.be.accessible();
 		});
 
@@ -49,6 +49,7 @@ describe('attribute-picker', () => {
 			const assignableAttributeList = ['one', 'two', 'three', 'four', 'five', 'six'];
 			const el = await fixture(
 				html`<d2l-labs-attribute-picker
+						aria-label="attributes"
 						.attributeList="${attributeList}"
 						.assignableAttributes="${assignableAttributeList}">
 					</d2l-labs-attribute-picker>`


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] Backwards-compatible changes merged: https://github.com/BrightspaceUILabs/multi-select/pull/140

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [x] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.