### PR TITLE
fix: LURV-1168 - Add input changed event

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -452,6 +452,15 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		if (this._dropdownIndex >= 0) {
 			this.allowFreeform ? this._dropdownIndex = -1 : this._dropdownIndex = 0;
 		}
+
+		this.dispatchEvent(new CustomEvent('d2l-attribute-input-changed', {
+			bubbles: true,
+			composed: true,
+			detail: {
+				text: this._text
+			}
+		}));
+
 		this.requestUpdate();
 	}
 


### PR DESCRIPTION
LLG Accessibility - Combobox has unclear delete instructions for keyboard
https://desire2learn.atlassian.net/browse/LURV-1168

**Context**:
It may be the case that a parent component needs to update the `assignable-attributes` based on the text input. This would be required if the backend limits/paginates autocomplete results, and we need to narrow down the autocomplete options as the user types a more specific string.

**Quality**:
It is small.