### PR TITLE
Lit 2 Phase 3 - Install Lit & Update Import Paths

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/colors/colors.js';
 import './multi-select-list.js';
 import './multi-select-list-item.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { Localizer } from './localization.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';

--- a/multi-select-list-item.js
+++ b/multi-select-list-item.js
@@ -2,7 +2,7 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/offscreen/offscreen.js';
 import '@brightspace-ui/core/components/tooltip/tooltip.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { Localizer } from './localization.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/core/components/button/button-subtle.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { getComposedChildren, isComposedAncestor } from '@brightspace-ui/core/helpers/dom.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "@brightspace-ui/core": "^2",
     "@brightspace-ui/localize-behavior": "^2",
     "@polymer/polymer": "^3",
-    "lit-element": "^3"
+    "lit": "^2"
   }
 }


### PR DESCRIPTION
Context for [US138194](https://rally1.rallydev.com/#/?detail=/userstory/631784781001&fdp=true): Lit 2.0 Phase 3 (Clean Up)

As part of the third and final phase of the Lit 2 migration, we have to replace the `lit-element` and `lit-html` dependencies with just `lit`, plus we have to update the respective imports.

- [x] `lit-element/lit-element.js` -> `lit`
- [x] `lit-html/directives` -> `lit/directives`
- [x] `nothing from 'lit-html'` -> `nothing from 'lit'`
- [x] `noChange from 'lit-html'` -> `noChange from 'lit'`
- [x] search repo for `lit-html` and `lit-element`, found ONLY in `package-lock.json` (installed by the Lit package)