### PR TITLE
US135822 Integrate Message Format Validator

### DIFF
--- a/.github/workflows/lang.yml
+++ b/.github/workflows/lang.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, AWS]
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node

--- a/.github/workflows/lang.yml
+++ b/.github/workflows/lang.yml
@@ -1,0 +1,22 @@
+name: Lang
+on:
+  pull_request:
+    paths:
+      - 'lang/**'
+jobs:
+  test:
+    timeout-minutes: 5
+    runs-on: [self-hosted, Linux, AWS]
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version-file: .nvmrc
+      - name: Add CodeArtifact npm registry
+        uses: Brightspace/codeartifact-actions/npm/add-registry@main
+        with:
+          auth-token: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
+      - name: Install MessageFormat-Validator
+        run: npm install messageformat-validator
+      - name: Run MessageFormat-Validator
+        run: npm run lint:langs

--- a/.github/workflows/lang.yml
+++ b/.github/workflows/lang.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     timeout-minutes: 5
-    runs-on: [self-hosted, Linux, AWS]
+    runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node

--- a/mfv.config.json
+++ b/mfv.config.json
@@ -1,0 +1,5 @@
+{
+  "source": "en",
+  "path": "lang/",
+  "locales": "ar,cy,da,de,en-us,en,es-es,es,fr-fr,fr-on,fr,hi,ja,ko,nl,pt,sv,tr,zh-cn,zh-tw"
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
+    "lint:langs": "mfv -e -i untranslated",
     "lint:lit": "lit-analyzer  \"{demo,test}/**/*.js\" --strict --rules.no-unknown-tag-name off --rules.no-incompatible-type-binding off --rules.no-unknown-attribute off --rules.no-unknown-property off",
     "lint:style": "stylelint \"**/*.{js,html}\"",
     "start": "web-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
@@ -44,6 +45,7 @@
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
     "lit-analyzer": "^1",
+    "messageformat-validator": "^2.4.1",
     "sinon": "^14",
     "stylelint": "^14"
   },


### PR DESCRIPTION
Context for [US135822](https://rally1.rallydev.com/#/?detail=/userstory/623964534735&fdp=true): Discover UI - Integrate MessageFormat-Validator in our FE Repos

This PR adds `npm run lint:langs` and makes it only run in the case where a localization file is changed, this way it only triggers when this lint test is actually required.