### PR TITLE
DE49784: Discover: Enrollment rule dialogue box: Search is not working for the vales of 'Role in Organization' attribute

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -152,7 +152,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		const hash = {};
 		this.attributeList.forEach(item => hash[item.name] = true);
 		const comparableText = this._text.toLowerCase();
-		const availableAttributes = this.assignableAttributes.filter(x => hash[x.name] !== true && (comparableText === '' || x.name.toLowerCase().includes(comparableText)));
+		const availableAttributes = this.assignableAttributes.filter(x => hash[x.name] !== true && (comparableText === '' || x.name?.toLowerCase().includes(comparableText)));
 
 		return html`
 		<div role="application" class="d2l-attribute-picker-container ${this._inputFocused ? 'd2l-attribute-picker-container-focused' : ''}">


### PR DESCRIPTION
[DE49784](https://rally1.rallydev.com/#/?detail=/defect/645374278571&fdp=true): Discover: Enrollment rule dialogue box: Search is not working for the vales of 'Role in Organization' attribute

See Brad's comment, role id 69 lacks a name, so make a check in general for a name to be defined and call a search. No need to not fetch d2lsupport unless there is an explicit reason not to? This isn't the repo for it, but I can make an adjustment to the attribute-picker to not include d2lsupport when constructing the assignableAttributes as per Brad's actual proposed possible solution.

This PR works and was tested via dev console editing and running directly on space1automation.