### PR TITLE
DE52759 Fix Attribute Aria-label

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -4,6 +4,7 @@ import './multi-select-list-item.js';
 import { css, html, LitElement } from 'lit';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { Localizer } from './localization.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 const keyCodes = {
@@ -156,7 +157,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 		return html`
 		<div role="application" class="d2l-attribute-picker-container ${this._inputFocused ? 'd2l-attribute-picker-container-focused' : ''}">
-			<div class="d2l-attribute-picker-content" role="${this.attributeList.length > 0 ? 'list' : ''}">
+			<div class="d2l-attribute-picker-content" aria-busy="${this._isNotActive()}" role="${this.attributeList.length > 0 ? 'list' : ''}">
 				${this.attributeList.map((item, index) => html`
 					<d2l-labs-multi-select-list-item
 						class="d2l-attribute-picker-attribute"
@@ -186,7 +187,6 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 					role="combobox"
 					type="text"
 					.value="${this._text}">
-				</input>
 			</div>
 
 			<div class="d2l-attribute-picker-absolute-container">
@@ -195,9 +195,9 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 					?hidden="${!this._inputFocused || this.hideDropdown || availableAttributes.length === 0}"
 					class="d2l-attribute-list">
 
-					${availableAttributes.map((item, listIndex) => html`
+					${repeat(availableAttributes, (item) => item.name, (item, listIndex) => html`
 						<li id="attribute-dropdown-list-item-${listIndex}"
-							aria-label="${this.localize('picker_add_value', 'value', item)}"
+							aria-label="${this.localize('picker_add_value', 'value', item.name)}"
 							aria-selected="${this._dropdownIndex === listIndex ? true : false}"
 							role="option"
 							class="d2l-attribute-picker-li ${this._dropdownIndex === listIndex ? 'd2l-selected' : ''}"
@@ -296,6 +296,10 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		const selectedAttributes = this.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');
 		this._activeAttributeIndex = index;
 		selectedAttributes[index].focus();
+	}
+
+	_isNotActive() {
+		return this._activeAttributeIndex === -1 && this._dropdownIndex === -1 && !this._inputFocused;
 	}
 
 	// Absolute value % operator for navigating menus.


### PR DESCRIPTION
Context for [DE52759](https://rally1.rallydev.com/#/?detail=/defect/694746946935&fdp=true): Enrollment Rules Attributes not Accessible

The purpose of this PR is to resolve an accessibility defect regarding using NVDA with the attribute-picker where selecting an available attribute read out `Click to add value [object Object] 1 of 3` instead of `Click to add value Learner 1 of 3`, this was because it was setting the `aria-label` property to the object containing the attribute's information rather than passing in the name of the attribute itself. This PR rectifies this. 

In addition, I had to replace the use of `availableAttributes.map` with Lit's [`repeat`](https://lit.dev/docs/templates/directives/#repeat) directive due to another accessibility defect where selecting an available attribute wouldn't inform the user of the new option they're hovering over once they click `Enter` to add the previous attribute. This was because it the index wasn't changing so it didn't realize that the option you selected was no longer there.

I also fixed another issue where the accessibility tests were failing prior to my changes because it doesn't like the fact that the input value (with the `combobox` role) was included under something with a `list` role. This was fixed by making use of the `aria-busy` attribute when the component isn't being used.