### PR TITLE
attribute-picker: Add enterkeyhint attribute to input so that 'Enter' is used on Android instead of 'Next'

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -180,6 +180,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 					aria-label="${this.ariaLabel}"
 					aria-owns="attribute-dropdown-list"
 					class="d2l-input d2l-attribute-picker-input"
+					enterkeyhint="enter"
 					@blur="${this._onInputBlur}"
 					@focus="${this._onInputFocus}"
 					@keydown="${this._onInputKeydown}"


### PR DESCRIPTION
**Context:**
When trying to use the attribute picker on an Android phone, in Chrome, I was not able to see or use the "enter" key. I tried the Samsung keyboard and Google's Gboard. It seems the keyboard on Android will show a "Next" key rather than the "Enter" key for certain form inputs. So it's not picked up in the attribute-picker's event handler.

This doesn't happen on iOS phones.

You can also see this issue from the Nova repo which has a video of the issue: https://github.com/Brightspace/nova/issues/4728

The fix in this PR is to add the `enterkeyhint="enter"` attribute to the input field so that the 'Enter' key is shown rather than the 'Next' key.

**Quality:**
I tested this on my Android phone where issue initially occurred.
Also asked a teammate to test on their iOS phone and confirmed the behaviour is the same as before. (i.e. it works as expected)

If there is any other quality check needed for this, let me know and I can do more testing
