### PR TITLE
switch border colour to gelena

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -68,7 +68,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			}
 			.d2l-attribute-picker-container {
 				background-color: white;
-				border-color: var(--d2l-color-mica);
+				border-colour: var(--d2l-color-galena);
 				border-radius: 6px;
 				border-style: solid;
 				border-width: 1px;

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -68,7 +68,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			}
 			.d2l-attribute-picker-container {
 				background-color: white;
-				border-colour: var(--d2l-color-galena);
+				border-color: var(--d2l-color-galena);
 				border-radius: 6px;
 				border-style: solid;
 				border-width: 1px;


### PR DESCRIPTION
The D2L input standards have adjusted and the input border colour is now `gelena` -> adjustiing this for the attribute picker