### PR TITLE
US156307 Attribute Picker Invalid State

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Unit Tests (cross-browser)
-        run: npx web-test-runner --config web-test-runner.config.js --group default --playwright --browsers chromium firefox webkit
+        run: npx web-test-runner --config web-test-runner.config.js --group all-browsers

--- a/.github/workflows/lang.yml
+++ b/.github/workflows/lang.yml
@@ -6,16 +6,12 @@ on:
 jobs:
   test:
     timeout-minutes: 5
-    runs-on: [self-hosted, Linux, AWS]
+    runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version-file: .nvmrc
-      - name: Add CodeArtifact npm registry
-        uses: Brightspace/codeartifact-actions/npm/add-registry@main
-        with:
-          auth-token: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
       - name: Install MessageFormat-Validator
         run: npm install messageformat-validator
       - name: Run MessageFormat-Validator

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -1,4 +1,5 @@
 import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/tooltip/tooltip.js';
 import './multi-select-list.js';
 import './multi-select-list-item.js';
 import { css, html, LitElement } from 'lit';
@@ -202,7 +203,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		const ariaRequired = this.required ? true : undefined;
 
 		return html`
-		<div role="application" class="${classMap(containerClasses)}" aria-invalid="${ifDefined(ariaInvalid)}" aria-required=${ifDefined(ariaRequired)}>
+		<div role="application" id="d2l-attribute-picker-container" class="${classMap(containerClasses)}" aria-invalid="${ifDefined(ariaInvalid)}" aria-required=${ifDefined(ariaRequired)}>
 			<div class="d2l-attribute-picker-content" aria-busy="${this._isNotActive()}" role="${this.attributeList.length > 0 ? 'list' : ''}">
 				${this.attributeList.map((item, index) => html`
 					<d2l-labs-multi-select-list-item
@@ -261,6 +262,10 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				</ul>
 			</div>
 		</div>
+
+		${!isValid ? html`
+			<d2l-tooltip for="d2l-attribute-picker-container" state="error" announced position="top" ?force-show=${this._inputFocused}>${this.localize('oneAttributeRequired')}</d2l-tooltip>
+		` : null}
 		`;
 	}
 

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -39,6 +39,12 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			/* When true, the autocomplete dropdown will not be displayed to the user. */
 			hideDropdown: { type: Boolean, attribute: 'hide-dropdown', reflect: true },
 
+			/*
+				The text that will appear in the tooltip that informs a user that the state is invalid
+				The default value is: 'At least one attribute must be set'
+			*/
+			invalidTooltipText: { type: String, attribute: 'invalid-tooltip-text', reflect: true },
+
 			/* The maximum number of attributes permitted. */
 			limit: { type: Number, attribute: 'limit', reflect: true },
 
@@ -264,7 +270,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		</div>
 
 		${!isValid ? html`
-			<d2l-tooltip for="d2l-attribute-picker-container" state="error" announced position="top" ?force-show=${this._inputFocused}>${this.localize('oneAttributeRequired')}</d2l-tooltip>
+			<d2l-tooltip for="d2l-attribute-picker-container" state="error" announced position="top" ?force-show=${this._inputFocused}>${this.invalidTooltipText || this.localize('oneAttributeRequired')}</d2l-tooltip>
 		` : null}
 		`;
 	}

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -2,6 +2,8 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import './multi-select-list.js';
 import './multi-select-list-item.js';
 import { css, html, LitElement } from 'lit';
+import { classMap } from 'lit-html/directives/class-map.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { Localizer } from './localization.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -39,8 +41,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			/* The maximum number of attributes permitted. */
 			limit: { type: Number, attribute: 'limit', reflect: true },
 
-			/* The inner text of the input. */
-			_text: { type: String, attribute: 'text', reflect: true },
+			/* When true, an error state will appear if no attributes are set. */
+			required: { type: Boolean, attribute: 'required', reflect: true },
 
 			/* Represents the index of the currently focused attribute. If no attribute is focused, equals -1. */
 			_activeAttributeIndex: { type: Number, reflect: false },
@@ -48,8 +50,14 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			/* Represents the index of the currently focused dropdown list item. If no item is focused, equals -1. */
 			_dropdownIndex: { type: Number, reflect: false },
 
+			/* When true, the user has yet to lose focus for the first time, meaning the validation won't be shown until they've lost focus for the first time. */
+			_initialFocus: { type: Boolean, reflect: false },
+
 			/* When true, the user currently has focus within the input. */
 			_inputFocused: { type: Boolean, reflect: false },
+
+			/* The inner text of the input. */
+			_text: { type: String, attribute: 'text', reflect: true }
 		};
 	}
 
@@ -77,12 +85,20 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				position: relative;
 				vertical-align: middle;
 			}
+
+			.d2l-attribute-picker-container:hover,
 			.d2l-attribute-picker-container-focused {
 				border-color: var(--d2l-color-celestine);
 				border-width: 2px;
 				outline-width: 0;
 				padding: 4px 4px 4px 4px;
 			}
+
+			.d2l-attribute-picker-container-error,
+			.d2l-attribute-picker-container-error:hover {
+				border-color: var(--d2l-color-cinnabar);
+			}
+
 			.d2l-attribute-picker-content {
 				cursor: text;
 				display: flex;
@@ -134,6 +150,23 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				width: 100%;
 				z-index: 1;
 			}
+
+			.d2l-input-text-invalid-icon {
+				background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgIDxwYXRoIGZpbGw9IiNGRkYiIGQ9Ik0wIDBoMjJ2MjJIMHoiLz4KICAgIDxwYXRoIGQ9Ik0xOC44NjQgMTYuNDdMMTIuNjIzIDMuOTg5YTEuNzgzIDEuNzgzIDAgMDAtMy4xOTIgMEwzLjE4OSAxNi40N2ExLjc2MSAxLjc2MSAwIDAwLjA4IDEuNzNjLjMyNS41MjUuODk4Ljc5OCAxLjUxNi43OTloMTIuNDgzYy42MTggMCAxLjE5Mi0uMjczIDEuNTE2LS44LjIzNy0uMzM1LjI2NS0xLjM3LjA4LTEuNzN6IiBmaWxsPSIjQ0QyMDI2IiBmaWxsLXJ1bGU9Im5vbnplcm8iLz4KICAgIDxwYXRoIGQ9Ik0xMS4wMjcgMTcuMjY0YTEuMzM3IDEuMzM3IDAgMTEwLTIuNjc1IDEuMzM3IDEuMzM3IDAgMDEwIDIuNjc1ek0xMS45IDEyLjk4YS44OTIuODkyIDAgMDEtMS43NDcgMEw5LjI3IDguNTJhLjg5Mi44OTIgMCAwMS44NzQtMS4wNjRoMS43NjhhLjg5Mi44OTIgMCAwMS44NzQgMS4wNjVsLS44ODYgNC40NTh6IiBmaWxsPSIjRkZGIi8+CiAgPC9nPgo8L3N2Zz4K");
+				display: flex;
+				height: 22px;
+				left: unset;
+				position: absolute;
+				right: 8px;
+				top: 50%;
+				transform: translateY(-50%);
+				width: 22px;
+			}
+
+			:host([dir='rtl']) .d2l-input-text-invalid-icon {
+				left: 8px;
+				right: unset;
+			}
 		`];
 	}
 
@@ -146,6 +179,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		this._inputFocused = false;
 		this._activeAttributeIndex = -1;
 		this._dropdownIndex = -1;
+		this._initialFocus = true;
+		this.required = false;
 	}
 
 	render() {
@@ -155,8 +190,19 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		const comparableText = this._text.toLowerCase();
 		const availableAttributes = this.assignableAttributes.filter(x => hash[x.name] !== true && (comparableText === '' || x.name?.toLowerCase().includes(comparableText)));
 
+		const isValid = this._initialFocus || !this.required || this.attributeList.length;
+
+		const containerClasses = {
+			'd2l-attribute-picker-container': true,
+			'd2l-attribute-picker-container-focused' : this._inputFocused,
+			'd2l-attribute-picker-container-error' : !isValid
+		};
+
+		const ariaInvalid = !isValid ? true : undefined;
+		const ariaRequired = this.required ? true : undefined;
+
 		return html`
-		<div role="application" class="d2l-attribute-picker-container ${this._inputFocused ? 'd2l-attribute-picker-container-focused' : ''}">
+		<div role="application" class="${classMap(containerClasses)}" aria-invalid="${ifDefined(ariaInvalid)}" aria-required=${ifDefined(ariaRequired)}>
 			<div class="d2l-attribute-picker-content" aria-busy="${this._isNotActive()}" role="${this.attributeList.length > 0 ? 'list' : ''}">
 				${this.attributeList.map((item, index) => html`
 					<d2l-labs-multi-select-list-item
@@ -175,19 +221,22 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				<input
 					aria-activedescendant="${this._dropdownIndex > -1 ? `attribute-dropdown-list-item-${this._dropdownIndex}` : ''}"
 					aria-autocomplete="list"
-					aria-haspopup="true"
 					aria-expanded="${this._inputFocused}"
+					aria-haspopup="true"
 					aria-label="${this.ariaLabel}"
 					aria-owns="attribute-dropdown-list"
 					class="d2l-input d2l-attribute-picker-input"
 					enterkeyhint="enter"
 					@blur="${this._onInputBlur}"
 					@focus="${this._onInputFocus}"
+					@focusout="${this._onInputLoseFocus}"
 					@keydown="${this._onInputKeydown}"
 					@input="${this._onInputTextChanged}"
 					role="combobox"
 					type="text"
 					.value="${this._text}">
+
+				${(!isValid && !this._inputFocused) ? html`<div class="d2l-input-text-invalid-icon" @click="${this._handleInvalidIconClick}"></div>` : null}
 			</div>
 
 			<div class="d2l-attribute-picker-absolute-container">
@@ -297,6 +346,13 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		const selectedAttributes = this.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');
 		this._activeAttributeIndex = index;
 		selectedAttributes[index].focus();
+	}
+
+	_handleInvalidIconClick() {
+		const input = this.shadowRoot && this.shadowRoot.querySelector('input');
+		if (!input) return;
+		this._inputFocused = true;
+		input.focus();
 	}
 
 	_isNotActive() {
@@ -450,6 +506,10 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				break;
 			}
 		}
+	}
+
+	_onInputLoseFocus() {
+		this._initialFocus = false;
 	}
 
 	_onInputTextChanged(event) {

--- a/demo/attribute-picker.html
+++ b/demo/attribute-picker.html
@@ -47,6 +47,15 @@
 				assignable-attributes='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6},{"name":"seven","value":7}]'
 			></d2l-labs-attribute-picker>
 		</d2l-demo-snippet>
+
+		<h2>d2l-labs-attribute-picker - required (with validation)</h2>
+		<d2l-demo-snippet>
+			<d2l-labs-attribute-picker aria-label="attributes"
+				required
+				allow-freeform
+				assignable-attributes='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6},{"name":"seven","value":7}]'
+			></d2l-labs-attribute-picker>
+		</d2l-demo-snippet>
 	</d2l-demo-page>
 	</body>
 </html>

--- a/demo/attribute-picker.html
+++ b/demo/attribute-picker.html
@@ -51,6 +51,7 @@
 		<h2>d2l-labs-attribute-picker - required (with validation)</h2>
 		<d2l-demo-snippet>
 			<d2l-labs-attribute-picker aria-label="attributes"
+				invalid-tooltip-text="You're missing something"
 				required
 				allow-freeform
 				assignable-attributes='[{"name":"one","value":1},{"name":"two","value":2},{"name":"three","value":3},{"name":"four","value":4},{"name":"five","value":5},{"name":"six","value":6},{"name":"seven","value":7}]'

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -4,6 +4,7 @@ export default {
 	delete: "حذف",
 	hide: "إخفاء",
 	hiddenChildren: "+ {num} أكثر",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "انقر لإزالة القيمة {value}",
 	picker_add_value: "انقر لإضافة القيمة {value}"
 };

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -4,7 +4,7 @@ export default {
 	delete: "حذف",
 	hide: "إخفاء",
 	hiddenChildren: "+ {num} أكثر",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "انقر لإزالة القيمة {value}",
 	picker_add_value: "انقر لإضافة القيمة {value}"
 };

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -4,7 +4,7 @@ export default {
 	delete: "حذف",
 	hide: "إخفاء",
 	hiddenChildren: "+ {num} أكثر",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "انقر لإزالة القيمة {value}",
 	picker_add_value: "انقر لإضافة القيمة {value}"
 };

--- a/lang/cy-gb.js
+++ b/lang/cy-gb.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Cuddio",
 	hiddenChildren: "+ {num} arall",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliciwch i dynnu'r gwerth {value}",
 	picker_add_value: "Cliciwch i ychwanegu'r gwerth {value}"
 };

--- a/lang/cy-gb.js
+++ b/lang/cy-gb.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Cuddio",
 	hiddenChildren: "+ {num} arall",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliciwch i dynnu'r gwerth {value}",
 	picker_add_value: "Cliciwch i ychwanegu'r gwerth {value}"
 };

--- a/lang/cy-gb.js
+++ b/lang/cy-gb.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Cuddio",
 	hiddenChildren: "+ {num} arall",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliciwch i dynnu'r gwerth {value}",
 	picker_add_value: "Cliciwch i ychwanegu'r gwerth {value}"
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Dileu",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Dileu",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Dileu",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/da-dk.js
+++ b/lang/da-dk.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Skjul",
 	hiddenChildren: "+ {num} mere",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klik for at fjerne værdi {value}",
 	picker_add_value: "Klik for at tilføje værdi {value}"
 };

--- a/lang/da-dk.js
+++ b/lang/da-dk.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Skjul",
 	hiddenChildren: "+ {num} mere",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klik for at fjerne værdi {value}",
 	picker_add_value: "Klik for at tilføje værdi {value}"
 };

--- a/lang/da-dk.js
+++ b/lang/da-dk.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Skjul",
 	hiddenChildren: "+ {num} mere",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klik for at fjerne værdi {value}",
 	picker_add_value: "Klik for at tilføje værdi {value}"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Slet",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Slet",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Slet",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Löschen",
 	hide: "Ausblenden",
 	hiddenChildren: "+ {num} weitere",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klicken Sie, um den Wert {value} zu entfernen",
 	picker_add_value: "Klicken Sie, um den Wert {value} hinzuzufügen"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Löschen",
 	hide: "Ausblenden",
 	hiddenChildren: "+ {num} weitere",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klicken Sie, um den Wert {value} zu entfernen",
 	picker_add_value: "Klicken Sie, um den Wert {value} hinzuzufügen"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Löschen",
 	hide: "Ausblenden",
 	hiddenChildren: "+ {num} weitere",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klicken Sie, um den Wert {value} zu entfernen",
 	picker_add_value: "Klicken Sie, um den Wert {value} hinzuzufügen"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Delete",
 	hide: "Hide",
 	hiddenChildren: "+ {num} more",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Eliminar",
 	hide: "Ocultar",
 	hiddenChildren: "+ {num} más",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Haga clic para eliminar el valor {value}",
 	picker_add_value: "Haga clic para agregar el valor {value}"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Eliminar",
 	hide: "Ocultar",
 	hiddenChildren: "+ {num} más",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Haga clic para eliminar el valor {value}",
 	picker_add_value: "Haga clic para agregar el valor {value}"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Eliminar",
 	hide: "Ocultar",
 	hiddenChildren: "+ {num} más",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Haga clic para eliminar el valor {value}",
 	picker_add_value: "Haga clic para agregar el valor {value}"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Eliminar",
 	hide: "Ocultar",
 	hiddenChildren: "Más de {num} más",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Haga clic para eliminar el valor {value}",
 	picker_add_value: "Haga clic para agregar el valor {value}"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Eliminar",
 	hide: "Ocultar",
 	hiddenChildren: "Más de {num} más",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Haga clic para eliminar el valor {value}",
 	picker_add_value: "Haga clic para agregar el valor {value}"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Eliminar",
 	hide: "Ocultar",
 	hiddenChildren: "Más de {num} más",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Haga clic para eliminar el valor {value}",
 	picker_add_value: "Haga clic para agregar el valor {value}"
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} de plus",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} de plus",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} de plus",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr-on.js
+++ b/lang/fr-on.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} plus",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr-on.js
+++ b/lang/fr-on.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} plus",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr-on.js
+++ b/lang/fr-on.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} plus",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} plus",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} plus",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Supprimer",
 	hide: "Masquer",
 	hiddenChildren: "+ {num} plus",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Cliquer pour supprimer la valeur {value}",
 	picker_add_value: "Cliquer pour ajouter la valeur {value}"
 };

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -4,7 +4,7 @@ export default {
 	delete: "हटाएँ",
 	hide: "छुपाएँ",
 	hiddenChildren: "+ {num} और",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "मान {value} निकालने के लिए क्लिक करें",
 	picker_add_value: "मान {value} जोड़ने के लिए क्लिक करें"
 };

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -4,7 +4,7 @@ export default {
 	delete: "हटाएँ",
 	hide: "छुपाएँ",
 	hiddenChildren: "+ {num} और",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "मान {value} निकालने के लिए क्लिक करें",
 	picker_add_value: "मान {value} जोड़ने के लिए क्लिक करें"
 };

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -4,6 +4,7 @@ export default {
 	delete: "हटाएँ",
 	hide: "छुपाएँ",
 	hiddenChildren: "+ {num} और",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "मान {value} निकालने के लिए क्लिक करें",
 	picker_add_value: "मान {value} जोड़ने के लिए क्लिक करें"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -4,7 +4,7 @@ export default {
 	delete: "削除",
 	hide: "表示しない",
 	hiddenChildren: "他 {num} 件",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "クリックして値 {value} を削除",
 	picker_add_value: "クリックして値 {value} を追加"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -4,6 +4,7 @@ export default {
 	delete: "削除",
 	hide: "表示しない",
 	hiddenChildren: "他 {num} 件",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "クリックして値 {value} を削除",
 	picker_add_value: "クリックして値 {value} を追加"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -4,7 +4,7 @@ export default {
 	delete: "削除",
 	hide: "表示しない",
 	hiddenChildren: "他 {num} 件",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "クリックして値 {value} を削除",
 	picker_add_value: "クリックして値 {value} を追加"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -4,7 +4,7 @@ export default {
 	delete: "삭제",
 	hide: "숨기기",
 	hiddenChildren: "{num}개 이상",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "클릭하여 {value} 값을 제거합니다.",
 	picker_add_value: "클릭하여 값 {value}을(를) 추가합니다."
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -4,6 +4,7 @@ export default {
 	delete: "삭제",
 	hide: "숨기기",
 	hiddenChildren: "{num}개 이상",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "클릭하여 {value} 값을 제거합니다.",
 	picker_add_value: "클릭하여 값 {value}을(를) 추가합니다."
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -4,7 +4,7 @@ export default {
 	delete: "삭제",
 	hide: "숨기기",
 	hiddenChildren: "{num}개 이상",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "클릭하여 {value} 값을 제거합니다.",
 	picker_add_value: "클릭하여 값 {value}을(를) 추가합니다."
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Verwijderen",
 	hide: "Verbergen",
 	hiddenChildren: "+ nog {num}",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klik om waarde {value} te verwijderen",
 	picker_add_value: "Klik om waarde {value} toe te voegen"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Verwijderen",
 	hide: "Verbergen",
 	hiddenChildren: "+ nog {num}",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klik om waarde {value} te verwijderen",
 	picker_add_value: "Klik om waarde {value} toe te voegen"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Verwijderen",
 	hide: "Verbergen",
 	hiddenChildren: "+ nog {num}",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klik om waarde {value} te verwijderen",
 	picker_add_value: "Klik om waarde {value} toe te voegen"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Excluir",
 	hide: "Ocultar",
 	hiddenChildren: "+ {num} mais",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Clique para remover valor {value}",
 	picker_add_value: "Clique para adicionar valor {value}"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Excluir",
 	hide: "Ocultar",
 	hiddenChildren: "+ {num} mais",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Clique para remover valor {value}",
 	picker_add_value: "Clique para adicionar valor {value}"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Excluir",
 	hide: "Ocultar",
 	hiddenChildren: "+ {num} mais",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Clique para remover valor {value}",
 	picker_add_value: "Clique para adicionar valor {value}"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Ta bort",
 	hide: "Dölj",
 	hiddenChildren: "+ {num} till",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klicka för att ta bort värde {value}",
 	picker_add_value: "Klicka för att lägga till värde {value}"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Ta bort",
 	hide: "Dölj",
 	hiddenChildren: "+ {num} till",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klicka för att ta bort värde {value}",
 	picker_add_value: "Klicka för att lägga till värde {value}"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Ta bort",
 	hide: "Dölj",
 	hiddenChildren: "+ {num} till",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Klicka för att ta bort värde {value}",
 	picker_add_value: "Klicka för att lägga till värde {value}"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Sil",
 	hide: "Gizle",
 	hiddenChildren: "+ {num} adet daha",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "{value} değerini kaldırmak için tıklayın",
 	picker_add_value: "{value} değeri eklemek için tıklayın"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -4,7 +4,7 @@ export default {
 	delete: "Sil",
 	hide: "Gizle",
 	hiddenChildren: "+ {num} adet daha",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "{value} değerini kaldırmak için tıklayın",
 	picker_add_value: "{value} değeri eklemek için tıklayın"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -4,6 +4,7 @@ export default {
 	delete: "Sil",
 	hide: "Gizle",
 	hiddenChildren: "+ {num} adet daha",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "{value} değerini kaldırmak için tıklayın",
 	picker_add_value: "{value} değeri eklemek için tıklayın"
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -4,6 +4,7 @@ export default {
 	delete: "删除",
 	hide: "隐藏",
 	hiddenChildren: "+ {num} 更多",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -4,7 +4,7 @@ export default {
 	delete: "删除",
 	hide: "隐藏",
 	hiddenChildren: "+ {num} 更多",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -4,7 +4,7 @@ export default {
 	delete: "删除",
 	hide: "隐藏",
 	hiddenChildren: "+ {num} 更多",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "Click to remove value {value}",
 	picker_add_value: "Click to add value {value}"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -4,7 +4,7 @@ export default {
 	delete: "刪除",
 	hide: "隱藏",
 	hiddenChildren: "還有 {num} 個",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "按一下以移除值 {value}",
 	picker_add_value: "按一下以新增值 {value}"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -4,7 +4,7 @@ export default {
 	delete: "刪除",
 	hide: "隱藏",
 	hiddenChildren: "還有 {num} 個",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "按一下以移除值 {value}",
 	picker_add_value: "按一下以新增值 {value}"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -4,6 +4,7 @@ export default {
 	delete: "刪除",
 	hide: "隱藏",
 	hiddenChildren: "還有 {num} 個",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "按一下以移除值 {value}",
 	picker_add_value: "按一下以新增值 {value}"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -4,6 +4,7 @@ export default {
 	delete: "删除",
 	hide: "隐藏",
 	hiddenChildren: "还有 {num} 个",
+	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "单击以删除值 {value}",
 	picker_add_value: "单击以添加值 {value}"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -4,7 +4,7 @@ export default {
 	delete: "删除",
 	hide: "隐藏",
 	hiddenChildren: "还有 {num} 个",
-	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one value must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "单击以删除值 {value}",
 	picker_add_value: "单击以添加值 {value}"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -4,7 +4,7 @@ export default {
 	delete: "删除",
 	hide: "隐藏",
 	hiddenChildren: "还有 {num} 个",
-	oneAttributeRequired: "At least one attribute must be selected", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
+	oneAttributeRequired: "At least one attribute must be set", // Tooltip that appears when no values have been set and we need to inform the user that this is an invalid state
 	picker_remove_value: "单击以删除值 {value}",
 	picker_add_value: "单击以添加值 {value}"
 };

--- a/mfv.config.json
+++ b/mfv.config.json
@@ -1,5 +1,5 @@
 {
   "source": "en",
   "path": "lang/",
-  "locales": "ar,cy,da,de,en-us,en,es-es,es,fr-fr,fr-on,fr,hi,ja,ko,nl,pt,sv,tr,zh-cn,zh-tw"
+  "locales": "ar,cy,cy-gb,da,da-dk,de,en-us,en,es-es,es,fr-fr,fr-on,fr,hi,ja,ko,nl,pt,sv,tr,zh,zh-cn,zh-tw"
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "multi-select-list.js"
   ],
   "scripts": {
+    "langs:sync": "mfv add-missing && mfv remove-extraneous",
     "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:langs": "mfv -e -i untranslated",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint:style": "stylelint \"**/*.{js,html}\"",
     "start": "web-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
     "test": "npm run lint && npm run test:headless",
-    "test:headless": "web-test-runner --node-resolve"
+    "test:headless": "web-test-runner --group all-browsers",
+    "test:headless:watch": "web-test-runner --group watch --watch"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
@@ -39,6 +40,7 @@
     "@open-wc/testing": "^3",
     "@web/dev-server": "^0.3.0",
     "@web/test-runner": "^0.17",
+    "@web/test-runner-playwright": "^0.10.1",
     "eslint": "^8",
     "eslint-config-brightspace": "^0.25",
     "lit-analyzer": "^1",

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -418,7 +418,11 @@ describe('attribute-picker', () => {
 
 			tooltip = el.shadowRoot.querySelector('d2l-tooltip');
 			expect(tooltip).to.exist;
-			expect(tooltip.innerHTML).to.contain('At least one attribute must be selected');
+			expect(tooltip.innerHTML).to.contain('At least one attribute must be set');
+
+			el.invalidTooltipText = 'blah blah blah';
+			await el.updateComplete;
+			expect(tooltip.innerHTML).to.contain('blah blah blah');
 
 			el.addAttribute(attributeList[0]);
 			await el.updateComplete;

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -374,6 +374,49 @@ describe('attribute-picker', () => {
 			expect(listItems[0].deletable).equal(false);
 		});
 
+		it('should mark as invalid if empty and required after unfocusing', async() => {
+			el = await fixture(html`<d2l-labs-attribute-picker required allow-freeform .assignableAttributes="${assignableAttributeList}"></d2l-labs-attribute-picker>`);
+
+			const listItems = el.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');
+			for (const item of listItems) {
+				await item.updateComplete;
+			}
+
+			const attributeContainer = el.shadowRoot.querySelector('.d2l-attribute-picker-container');
+			expect(attributeContainer).to.exist;
+			expect(attributeContainer.hasAttribute('aria-required')).to.be.true;
+			expect(attributeContainer.hasAttribute('aria-invalid')).to.be.false; // Doesn't have this attribute yet since it hasn't been unfocused yet
+
+			expect(el.required).to.be.true;
+			expect(el._inputFocused).to.be.false;
+			expect(el._initialFocus).to.be.true;
+
+			const pageNumberInput = el.shadowRoot.querySelector('input');
+			pageNumberInput.focus();
+			await el.updateComplete;
+
+			expect(el._inputFocused).to.be.true;
+			expect(el._initialFocus).to.be.true;
+
+			pageNumberInput.blur(); // unfocuses
+			await el.updateComplete;
+
+			expect(el._inputFocused).to.be.false;
+			expect(el._initialFocus).to.be.false;
+
+			expect(attributeContainer.hasAttribute('aria-required')).to.be.true;
+			expect(attributeContainer.hasAttribute('aria-invalid')).to.be.true;
+
+			let invalidIcon = el.shadowRoot.querySelector('.d2l-input-text-invalid-icon');
+			expect(invalidIcon).to.exist;
+
+			el.addAttribute(attributeList[0]);
+			await el.updateComplete;
+
+			expect(attributeContainer.hasAttribute('aria-invalid')).to.be.false;
+			invalidIcon = el.shadowRoot.querySelector('.d2l-input-text-invalid-icon');
+			expect(invalidIcon).to.not.exist;
+		});
 	});
 
 	describe('eventing', () => {

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -418,7 +418,7 @@ describe('attribute-picker', () => {
 
 			tooltip = el.shadowRoot.querySelector('d2l-tooltip');
 			expect(tooltip).to.exist;
-			expect(tooltip.innerHTML).to.contain('At least one attribute must be set');
+			expect(tooltip.innerHTML).to.contain('At least one value must be set');
 
 			el.invalidTooltipText = 'blah blah blah';
 			await el.updateComplete;

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -391,6 +391,12 @@ describe('attribute-picker', () => {
 			expect(el._inputFocused).to.be.false;
 			expect(el._initialFocus).to.be.true;
 
+			let invalidIcon = el.shadowRoot.querySelector('.d2l-input-text-invalid-icon');
+			expect(invalidIcon).to.not.exist;
+
+			let tooltip = el.shadowRoot.querySelector('d2l-tooltip');
+			expect(tooltip).to.not.exist;
+
 			const pageNumberInput = el.shadowRoot.querySelector('input');
 			pageNumberInput.focus();
 			await el.updateComplete;
@@ -407,15 +413,23 @@ describe('attribute-picker', () => {
 			expect(attributeContainer.hasAttribute('aria-required')).to.be.true;
 			expect(attributeContainer.hasAttribute('aria-invalid')).to.be.true;
 
-			let invalidIcon = el.shadowRoot.querySelector('.d2l-input-text-invalid-icon');
+			invalidIcon = el.shadowRoot.querySelector('.d2l-input-text-invalid-icon');
 			expect(invalidIcon).to.exist;
+
+			tooltip = el.shadowRoot.querySelector('d2l-tooltip');
+			expect(tooltip).to.exist;
+			expect(tooltip.innerHTML).to.contain('At least one attribute must be selected');
 
 			el.addAttribute(attributeList[0]);
 			await el.updateComplete;
 
 			expect(attributeContainer.hasAttribute('aria-invalid')).to.be.false;
+
 			invalidIcon = el.shadowRoot.querySelector('.d2l-input-text-invalid-icon');
 			expect(invalidIcon).to.not.exist;
+
+			tooltip = el.shadowRoot.querySelector('d2l-tooltip');
+			expect(tooltip).to.not.exist;
 		});
 	});
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,10 +1,54 @@
+import { playwrightLauncher } from '@web/test-runner-playwright';
+
+const createPage = async({ context }) => {
+	const page = await context.newPage();
+	await page.emulateMedia({ reducedMotion: 'reduce' });
+	return page;
+};
+
 export default {
 	files: 'test/*.test.js',
 	nodeResolve: true,
+	groups: [
+		{
+			name: 'watch',
+			concurrency: 2,
+			browsers: [
+				playwrightLauncher({
+					product: 'chromium',
+					createPage
+				})
+			]
+		},
+		{
+			name: 'all-browsers',
+			browsers: [
+				playwrightLauncher({
+					product: 'chromium',
+					createPage
+				}),
+				playwrightLauncher({
+					product: 'firefox',
+					createPage
+				}),
+				playwrightLauncher({
+					product: 'webkit',
+					createPage
+				})
+			]
+		}
+	],
 	testFramework: {
 		config: {
 			ui: 'bdd',
-			timeout: '10000',
+			timeout: '20000',
 		}
-	}
+	},
+	testRunnerHtml: testFramework =>
+		`<html lang="en">
+			<body>
+				<script src="node_modules/@brightspace-ui/core/tools/resize-observer-test-error-handler.js"></script>
+				<script type="module" src="${testFramework}"></script>
+			</body>
+		</html>`
 };


### PR DESCRIPTION
Context for [US156307](https://rally1.rallydev.com/#/?detail=/userstory/719512834707&fdp=true): Add validation state to attribute-picker/multi-select

The purpose of this PR is to add an `invalid` state where if the `required` attribute is set to `true`, then in the event where nothing is set, then it will be outlined in red with an warning icon, similar what happens with the core [`d2l-input-text`](https://daylight.d2l.dev/components/text-input/#d2l-input-text) component.

## Screenshots

### Invalid State (default)

![image](https://github.com/BrightspaceUILabs/multi-select/assets/71081906/aa0ffada-dc40-46fe-b678-8590a37ab964)

### Invalid State (hovered)

![image](https://github.com/BrightspaceUILabs/multi-select/assets/71081906/22a26c16-de45-4856-8112-af61ffd771b9)

### Invalid State (focused)

![image](https://github.com/BrightspaceUILabs/multi-select/assets/71081906/8a8278f2-b868-4190-b443-8305b107ccea)
