### PR TITLE
Fix failing required axe test

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -209,7 +209,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		const ariaRequired = this.required ? true : undefined;
 
 		return html`
-		<div role="application" id="d2l-attribute-picker-container" class="${classMap(containerClasses)}" aria-invalid="${ifDefined(ariaInvalid)}" aria-required=${ifDefined(ariaRequired)}>
+		<div role="application" id="d2l-attribute-picker-container" class="${classMap(containerClasses)}" >
 			<div class="d2l-attribute-picker-content" aria-busy="${this._isNotActive()}" role="${this.attributeList.length > 0 ? 'list' : ''}">
 				${this.attributeList.map((item, index) => html`
 					<d2l-labs-multi-select-list-item
@@ -230,8 +230,10 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 					aria-autocomplete="list"
 					aria-expanded="${this._inputFocused}"
 					aria-haspopup="true"
+					aria-invalid="${ifDefined(ariaInvalid)}"
 					aria-label="${this.ariaLabel}"
 					aria-owns="attribute-dropdown-list"
+					aria-required=${ifDefined(ariaRequired)}
 					class="d2l-input d2l-attribute-picker-input"
 					enterkeyhint="enter"
 					@blur="${this._onInputBlur}"

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -44,6 +44,11 @@ describe('attribute-picker', () => {
 			await expect(el).to.be.accessible();
 		});
 
+		it('should pass all axe tests (with required attribute)', async() => {
+			const el = await fixture(html`<d2l-labs-attribute-picker required aria-label="attributes"></d2l-labs-attribute-picker>`);
+			await expect(el).to.be.accessible();
+		});
+
 		it('should pass all axe tests when populated', async() => {
 			const attributeList = ['one', 'two', 'three'];
 			const assignableAttributeList = ['one', 'two', 'three', 'four', 'five', 'six'];
@@ -382,7 +387,7 @@ describe('attribute-picker', () => {
 				await item.updateComplete;
 			}
 
-			const attributeContainer = el.shadowRoot.querySelector('.d2l-attribute-picker-container');
+			const attributeContainer = el.shadowRoot.querySelector('.d2l-attribute-picker-input');
 			expect(attributeContainer).to.exist;
 			expect(attributeContainer.hasAttribute('aria-required')).to.be.true;
 			expect(attributeContainer.hasAttribute('aria-invalid')).to.be.false; // Doesn't have this attribute yet since it hasn't been unfocused yet


### PR DESCRIPTION
So this PR is being made because while I was implementing [US156309](https://rally1.rallydev.com/#/?detail=/userstory/719514318767&fdp=true): Add error states to invalid rule components, an aXe test was failing because an element with the `application` role shouldn't make use of the `aria-required`. So, those were moved to the element with the `combobox` role, which allows for the `aria-required` attribute.

I've also added an extra aXe test here to verify that it passes.