### PR TITLE
Clean up Localization Pipeline

### DIFF
--- a/multi-select.serge.json
+++ b/multi-select.serge.json
@@ -6,21 +6,6 @@
     "output_file_path": "lang/%LANG%.js",
     "parser_plugin": {
       "plugin": "parse_js"
-    },
-    "output_lang_rewrite": [
-      "ar-sa ar",
-      "de-de de",
-      "es-mx es",
-      "fi-FI fi",
-      "fr-ca fr",
-      "ja-jp ja",
-      "ko-kr ko",
-      "nl-nl nl",
-      "pt-br pt",
-      "sv-se sv",
-      "tr-tr tr",
-      "zh-cn zh",
-      "zh-tw zh-tw"
-    ]
+    }
   }
 ]


### PR DESCRIPTION
After watching Danny's InFusion presentation, it looks like we're using some localization settings/files that we don't actually need, so this PR is removing those.

The things Danny suggested removing included:

1. Static Imports (this was already done in https://github.com/BrightspaceUILabs/multi-select/pull/228)
2. `output_lang_rewrite` in the `*.serge.json` file
3. Any files that don't match the [Supported Language Packs](https://desire2learn.atlassian.net/wiki/spaces/LD/pages/2237006473/List+of+Supported+Language+Packs) `Offstack Tag` list
    -   This repo doesn't have `en-us`, so we don't have any unsupported ones that we need to remove.