### PR TITLE
Added Deprecation Warnings & Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # d2l-labs-multi-select
 
+**The majority of this repo is deprecated, do not use any of the components in this repo and use [`d2l-tag-list` and `d2l-tag-list-item`](https://github.com/BrightspaceUI/core/tree/main/components/tag-list) in `BrightspaceUI/core` instead.**
+
+If you want to use `d2l-labs-attribute-picker`, contact Team Arkeltstorp first as it's going to be moved over to the [labs](https://github.com/BrightspaceUI/labs) monorepo.
+
 [![NPM version](https://img.shields.io/npm/v/@brightspace-ui-labs/multi-select.svg)](https://www.npmjs.org/package/@brightspace-ui-labs/multi-select)
 
 > Note: this is a ["labs" component](https://github.com/BrightspaceUI/guide/wiki/Component-Tiers). While functional, these tasks are prerequisites to promotion to BrightspaceUI "official" status:
@@ -26,35 +30,6 @@ npm install @brightspace-ui-labs/multi-select
 ```
 
 ## Components
-
-### `d2l-labs-multi-select-input-text`
-
-`d2l-labs-multi-select-input-text` includes a `d2l-input-text` that is hooked up to add items when 'Enter' is pressed.
-**Usage:**
-```html
-<d2l-labs-multi-select-input-text>
-	<d2l-labs-multi-select-list-item deletable text="Item 1"></d2l-labs-multi-select-list-item>
-</d2l-labs-multi-select-input-text>
-```
-
-### `d2l-labs-multi-select-input`
-
-You can use your own input component instead by putting it as a child of `d2l-labs-multi-select-input` and setting `slot="input"` on your input element. To add items to the list, call `addItem` with the item text.
-**Usage:**
-```html
-<d2l-labs-multi-select-input id="multi-select-input">
-	<div slot="input">
-		<input>
-		<button>Add</button>
-	</div>
-</d2l-labs-multi-select-input>
-```
-
-```js
-button.addEventListener('click', () => {
-	multiSelectInput.addItem(input.value)
-})
-```
 
 ### `d2l-labs-attribute-picker`
 
@@ -141,6 +116,34 @@ You can opt for a condensed view by adding the `collapsable` attribute, which li
 
 - `d2l-labs-multi-select-list-item-added`: fired on item added to the `d2l-labs-multi-select-list`
 
+### `d2l-labs-multi-select-input-text`
+
+`d2l-labs-multi-select-input-text` includes a `d2l-input-text` that is hooked up to add items when 'Enter' is pressed.
+**Usage:**
+```html
+<d2l-labs-multi-select-input-text>
+	<d2l-labs-multi-select-list-item deletable text="Item 1"></d2l-labs-multi-select-list-item>
+</d2l-labs-multi-select-input-text>
+```
+
+### `d2l-labs-multi-select-input`
+
+You can use your own input component instead by putting it as a child of `d2l-labs-multi-select-input` and setting `slot="input"` on your input element. To add items to the list, call `addItem` with the item text.
+**Usage:**
+```html
+<d2l-labs-multi-select-input id="multi-select-input">
+	<div slot="input">
+		<input>
+		<button>Add</button>
+	</div>
+</d2l-labs-multi-select-input>
+```
+
+```js
+button.addEventListener('click', () => {
+	multiSelectInput.addItem(input.value)
+})
+```
 
 ## Developing, Testing and Contributing
 

--- a/multi-select-input-text.js
+++ b/multi-select-input-text.js
@@ -2,6 +2,8 @@ import '@brightspace-ui/core/components/inputs/input-text.js';
 import './multi-select-input.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
+console.warn('The \'d2l-labs-multi-select-input-text\' component is deprecated and will soon be removed.');
+
 const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-input-text">
 	<template strip-whitespace>

--- a/multi-select-input.js
+++ b/multi-select-input.js
@@ -1,6 +1,8 @@
 import './multi-select-list.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
+console.warn('The \'d2l-labs-multi-select-input\' component is deprecated and will soon be removed.');
+
 const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<dom-module id="d2l-labs-multi-select-input">
 	<template strip-whitespace>

--- a/multi-select-list-item.js
+++ b/multi-select-list-item.js
@@ -218,6 +218,7 @@ class MultiSelectListItem extends RtlMixin(Localizer(LitElement)) {
 
 	constructor() {
 		super();
+		console.warn('The \'d2l-labs-multi-select-list-item\' component is deprecated and will soon be removed, please use the \'d2l-tag-list-item\' component instead. https://github.com/BrightspaceUI/core/tree/main/components/tag-list#tag-list-item-d2l-tag-list-item');
 		this.text = '';
 		this.shortText = '';
 		this.maxChars = 40;

--- a/multi-select-list.js
+++ b/multi-select-list.js
@@ -123,6 +123,7 @@ class MultiSelectList extends RtlMixin(Localizer(LitElement)) {
 
 	constructor() {
 		super();
+		console.warn('The \'d2l-labs-multi-select-list\' component is deprecated and will soon be removed, please use the \'d2l-tag-list\' component instead. https://github.com/BrightspaceUI/core/tree/main/components/tag-list#tag-list-d2l-tag-list');
 		this.autoremove = false;
 		this.collapsable = false;
 		this._collapsed = false;


### PR DESCRIPTION
We are currently looking at moving the `attribute-picker` component to the labs monorepo and graveyarding the rest of repo due to being either built in Polymer or having been deprecated in favour of the [`tag-list`](https://daylight.d2l.dev/components/tag-list/) components, we're adding warning when the Polymer or deprecated components get rendered to inform the teams that use them that they will need to make the switch before things get killed off.

Currently the 2 components built in Polymer aren't actually used anywhere, meaning that they could in theory just be deleted, but since we'll be archiving them anyway in the Graveyard, it makes sense to keep them for historical reasons. I will also be updating the [Multi-Select Daylight page](https://daylight.d2l.dev/components/multi-select/) to mention that they are deprecated and shouldn't be used.

I've also put up a [PR](https://github.com/BrightspaceUI/documentation/pull/1851) to update the Multi-Select Daylight page.